### PR TITLE
Document `serve --sse` single-session limitation in README + TROUBLESHOOTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Connect to existing MCP servers and re-expose their tools with 40mcp's features 
   --require-bearer-env FRONTDOOR_TOKEN
 ```
 
+> **Note:** `link --sse` supports multiple concurrent clients; `serve --sse` is single-session only (second clients get "Already connected to a transport"). See [TROUBLESHOOTING.md](TROUBLESHOOTING.md#already-connected-to-a-transport-single-session-sse-on-serve) for workarounds.
+
 ```js
 import { connectStdio, connectFromConfig } from '40mcp';
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -605,6 +605,28 @@ curl http://localhost:3000/status
 client.close();
 ```
 
+### "Already connected to a transport" (single-session SSE on `serve`)
+
+**Symptom:** Second concurrent SSE client connection fails with `"Already connected to a transport"`.
+
+**Cause:** `cmdServe` uses one shared `Server` instance across SSE sessions; the MCP SDK's `Server.connect(transport)` rejects a second attachment while the first is active.
+
+**Workarounds:**
+
+1. **Use `link` instead of `serve`** — `cmdLink` mints a fresh `Server` per session:
+   ```bash
+   40mcp link .mcp.json --sse 8080 --host 0.0.0.0
+   ```
+
+2. **Front multiple `serve` instances behind a reverse proxy** — balance load across processes:
+   ```bash
+   # Terminal 1
+   40mcp serve config.json --sse 3001
+   # Terminal 2
+   40mcp serve config.json --sse 3002
+   # Then use nginx/HAProxy to load-balance across both
+   ```
+
 ### Session Cleanup Issues
 
 **Symptom:** Memory usage grows; old sessions don't disconnect.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -618,7 +618,7 @@ client.close();
    40mcp link .mcp.json --sse 8080 --host 0.0.0.0
    ```
 
-2. **Front multiple `serve` instances behind a reverse proxy** — balance load across processes:
+2. **Front multiple `serve` instances behind a reverse proxy** — each `serve` process supports one active SSE session, so run at least one process per expected concurrent client and route clients across them:
    ```bash
    # Terminal 1
    40mcp serve config.json --sse 3001


### PR DESCRIPTION
Closes #9

Adds documentation for the known limitation where `cmdServe` uses a single shared `Server` instance across SSE sessions, causing second concurrent clients to receive "Already connected to a transport" errors.

Changes:
- **TROUBLESHOOTING.md**: New section documenting the symptom, cause, and two workarounds (use `link` instead of `serve`, or front multiple `serve` instances with a reverse proxy)
- **README.md**: One-line callout in the MCP Server Linking section pointing readers to the TROUBLESHOOTING entry before they hit the issue in production

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDSK9ovs1zptZn1XZvJuJq)_