### PR TITLE
Require secret on non-loopback webhook routes; warn on loopback no-secret routes

### DIFF
--- a/src/webhook/listener.js
+++ b/src/webhook/listener.js
@@ -326,12 +326,27 @@ export function createWebhookListener(config) {
   }
 
   // Validate routes
+  // A01: mirror the reverse-bridge guard — hard-error on non-loopback routes
+  // without a secret; warn on loopback routes without a secret.
+  const bindHost = host;
+  const isLoopback = bindHost === '127.0.0.1' || bindHost === 'localhost' || bindHost === '::1';
+
   for (const route of routes) {
     if (!route.path || !SAFE_PATH_PATTERN.test(route.path)) {
       throw new BridgeError(BridgeErrorCode.CONFIG_INVALID, `Invalid webhook route path: "${route.path}"`);
     }
     if (!route.tool) {
       throw new BridgeError(BridgeErrorCode.CONFIG_MISSING_FIELD, `Webhook route ${route.path} requires a tool name`);
+    }
+    if (!route.secret) {
+      if (!isLoopback) {
+        throw new BridgeError(
+          BridgeErrorCode.CONFIG_INVALID,
+          `[${name}] Webhook route "${route.path}" has no secret configured but the listener is bound to non-loopback host "${bindHost}". ` +
+          `Set route.secret or bind to 127.0.0.1.`,
+        );
+      }
+      process.stderr.write(`[${name}] WARNING: webhook route "${route.path}" has no secret — all requests will be dispatched unauthenticated\n`);
     }
   }
 
@@ -539,7 +554,12 @@ export function createWebhookListener(config) {
     if (route.response !== 'sync') {
       res.setHeader('Content-Type', 'application/json');
       res.writeHead(202);
-      res.end(JSON.stringify({ status: 'accepted', tool: route.tool }));
+      // Omit the tool name on routes without a secret to reduce recon surface —
+      // an unauthenticated caller learns nothing about which tool is being dispatched.
+      const accepted202 = route.secret
+        ? { status: 'accepted', tool: route.tool }
+        : { status: 'accepted' };
+      res.end(JSON.stringify(accepted202));
 
       // Fire and forget — rate-limited error logging to prevent log flooding
       dispatch(route.tool, args)

--- a/src/webhook/listener.test.js
+++ b/src/webhook/listener.test.js
@@ -100,6 +100,82 @@ describe('createWebhookListener', () => {
       (err) => err.message.includes('requires a tool name'),
     );
   });
+
+  // ─── A01: non-loopback host without secret is a hard error ───────────────
+
+  it('throws when a route has no secret and host is 0.0.0.0', () => {
+    assert.throws(
+      () => createWebhookListener({
+        dispatch: async () => {},
+        host: '0.0.0.0',
+        routes: [{ path: '/hook', tool: 'test' }],
+      }),
+      (err) => err.message.includes('no secret') || err.message.includes('Set route.secret'),
+    );
+  });
+
+  it('throws when a route has no secret and host is a non-loopback IP', () => {
+    assert.throws(
+      () => createWebhookListener({
+        dispatch: async () => {},
+        host: '10.0.0.1',
+        routes: [{ path: '/hook', tool: 'test' }],
+      }),
+      (err) => err.message.includes('Set route.secret'),
+    );
+  });
+
+  it('does NOT throw when a route has no secret and host is 127.0.0.1 (loopback)', () => {
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => { stderrLines.push(String(msg)); return origWrite(msg, ...rest); };
+    try {
+      assert.doesNotThrow(
+        () => createWebhookListener({
+          dispatch: async () => {},
+          host: '127.0.0.1',
+          routes: [{ path: '/hook', tool: 'test' }],
+        }),
+      );
+      // A warning must be emitted for the unauthenticated loopback route
+      assert.ok(
+        stderrLines.some((l) => l.includes('WARNING') && l.includes('no secret')),
+        'Expected a WARNING stderr line about the missing secret',
+      );
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('does NOT throw when a route has no secret and host is localhost (loopback)', () => {
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => origWrite(msg, ...rest);
+    try {
+      assert.doesNotThrow(
+        () => createWebhookListener({
+          dispatch: async () => {},
+          host: 'localhost',
+          routes: [{ path: '/hook', tool: 'test' }],
+        }),
+      );
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('does NOT throw when a route HAS a secret and host is 0.0.0.0', () => {
+    assert.doesNotThrow(
+      () => createWebhookListener({
+        dispatch: async () => {},
+        host: '0.0.0.0',
+        routes: [{
+          path: '/hook',
+          tool: 'test',
+          secret: { type: 'header', envVar: '__TEST_WEBHOOK_SECRET' },
+        }],
+      }),
+    );
+  });
 });
 
 describe('webhook HTTP server', () => {
@@ -475,6 +551,69 @@ describe('webhook HTTP server', () => {
   });
 
   // ─── Async error rate limiter tests ──────────────────────────────────
+
+  // ─── 202 recon-reduction: tool field is omitted on no-secret routes ─────
+
+  it('202 response omits tool name on loopback routes without a secret', async () => {
+    const dispatch = createMockDispatch();
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => origWrite(msg, ...rest); // suppress warning noise in test output
+
+    try {
+      const listener = createWebhookListener({
+        dispatch,
+        port: 0,
+        host: '127.0.0.1',
+        routes: [{ path: '/hooks/test', tool: 'my_tool' }],
+      });
+      const { httpServer, url } = await listener.start();
+
+      try {
+        const res = await sendRequest(url, '/hooks/test', { body: { event: 'push' } });
+        assert.equal(res.status, 202);
+        const body = await res.json();
+        assert.equal(body.status, 'accepted');
+        assert.equal(body.tool, undefined, '202 must not echo tool name on no-secret routes (recon reduction)');
+      } finally {
+        httpServer.close();
+      }
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('202 response includes tool name on routes with a secret', async () => {
+    const dispatch = createMockDispatch();
+    process.env.__TEST_WEBHOOK_SECRET202 = 'secret-for-202-test';
+
+    try {
+      const listener = createWebhookListener({
+        dispatch,
+        port: 0,
+        routes: [{
+          path: '/hooks/test',
+          tool: 'my_tool',
+          secret: { type: 'header', header: 'x-webhook-secret', envVar: '__TEST_WEBHOOK_SECRET202' },
+        }],
+      });
+      const { httpServer, url } = await listener.start();
+
+      try {
+        const res = await sendRequest(url, '/hooks/test', {
+          body: {},
+          headers: { 'x-webhook-secret': 'secret-for-202-test' },
+        });
+        assert.equal(res.status, 202);
+        const body = await res.json();
+        assert.equal(body.status, 'accepted');
+        assert.equal(body.tool, 'my_tool', '202 must include tool name when route has a secret');
+      } finally {
+        httpServer.close();
+      }
+    } finally {
+      delete process.env.__TEST_WEBHOOK_SECRET202;
+    }
+  });
 
   it('suppresses repeated async dispatch errors after rate limit is reached', async () => {
     let dispatchCallCount = 0;


### PR DESCRIPTION
Closes #16

## Summary

- Hard-error at `createWebhookListener` construction time when any route has no `secret` and the listener is bound to a non-loopback host (mirrors the existing `reverse/server.js` A01 guard pattern exactly).
- Emit `process.stderr.write('[...] WARNING: ...')` at construction time for loopback-bound routes with no secret so the operator sees it on startup.
- Drop the `tool` field from 202 async responses on no-secret routes to reduce recon surface for unauthenticated callers (NOTE from issue).

## Test plan

- [ ] `throws when a route has no secret and host is 0.0.0.0` — hard error
- [ ] `throws when a route has no secret and host is a non-loopback IP` — hard error
- [ ] `does NOT throw when a route has no secret and host is 127.0.0.1 (loopback)` — warning emitted
- [ ] `does NOT throw when a route has no secret and host is localhost (loopback)`
- [ ] `does NOT throw when a route HAS a secret and host is 0.0.0.0` — no false positive
- [ ] `202 response omits tool name on loopback routes without a secret`
- [ ] `202 response includes tool name on routes with a secret`
- [ ] All existing 32 webhook listener tests still pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDSK9ovs1zptZn1XZvJuJq)_