### PR TITLE
Apply SSRF + prototype-pollution guards to generateFromSpec

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -10,6 +10,9 @@
 
 import { validateConfig } from './validate.js';
 import { toSnakeCase } from './core/path.js';
+import { assertSafeUrl } from './core/env.js';
+import { sanitizeDescription } from './core/sanitize.js';
+import { DANGEROUS_KEYS } from './core/object.js';
 
 /**
  * The system prompt that teaches an LLM how to generate 40mcp configs.
@@ -221,6 +224,18 @@ export function generateFromSpec(spec, options = {}) {
   const info = spec.info || {};
   const servers = spec.servers || [];
   const baseUrl = servers[0]?.url || '';
+
+  // SSRF guard: validate spec-derived base URL against the same policy used by
+  // openapi.js. A spec with servers[0].url = "http://169.254.169.254/..." would
+  // otherwise cause every dispatched tool call to hit cloud metadata or other
+  // internal infrastructure. Only validate when the spec actually supplies a URL.
+  if (baseUrl) {
+    assertSafeUrl(baseUrl, {
+      allowPrivate: options.allowPrivate === true,
+      label: 'generateFromSpec server url',
+    });
+  }
+
   const paths = spec.paths || {};
 
   const tools = [];
@@ -235,10 +250,19 @@ export function generateFromSpec(spec, options = {}) {
 
       const tool = {
         name,
-        description: operation.summary || operation.description || `${httpMethod} ${pathTemplate}`,
+        // Sanitize description: spec-supplied summary/description fields flow into
+        // the LLM tool list verbatim. Run through the prompt-injection scanner and
+        // replace matches with a neutral placeholder. Mirrors openapi.js:188-189.
+        description: sanitizeDescription(
+          operation.summary || operation.description || `${httpMethod} ${pathTemplate}`,
+          { label: 'generateFromSpec' },
+        ),
         method: httpMethod,
         path: pathTemplate.replace(/\{([^}]+)\}/g, ':$1'),
-        inputSchema: { type: 'object', properties: {}, required: [] },
+        // Use null-prototype object so spec-controlled parameter names (e.g.
+        // "__proto__", "constructor") cannot shadow Object.prototype keys.
+        // Mirrors openapi.js parametersToSchema (openapi.js:287).
+        inputSchema: { type: 'object', properties: Object.create(null), required: [] },
       };
 
       // Extract parameters
@@ -246,7 +270,16 @@ export function generateFromSpec(spec, options = {}) {
       const queryMap = {};
 
       for (const param of params) {
+        if (!param || !param.name) continue;
         const propName = toSnakeCase(param.name);
+        // Drop any parameter whose converted name collides with a reserved
+        // JS object key. Mirrors openapi.js parametersToSchema:300-305.
+        if (DANGEROUS_KEYS.has(propName)) {
+          process.stderr.write(
+            `[40mcp] generateFromSpec: dropped parameter "${param.name}" — reserved JS object key\n`,
+          );
+          continue;
+        }
         tool.inputSchema.properties[propName] = {
           type: param.schema?.type || 'string',
           description: param.description || param.name,
@@ -273,6 +306,13 @@ export function generateFromSpec(spec, options = {}) {
           const bodyMap = {};
           for (const [fieldName, fieldSchema] of Object.entries(content.schema.properties)) {
             const propName = toSnakeCase(fieldName);
+            // Drop reserved JS object keys. Mirrors openapi.js parametersToSchema:300-305.
+            if (DANGEROUS_KEYS.has(propName)) {
+              process.stderr.write(
+                `[40mcp] generateFromSpec: dropped body field "${fieldName}" — reserved JS object key\n`,
+              );
+              continue;
+            }
             tool.inputSchema.properties[propName] = {
               type: fieldSchema.type || 'string',
               description: fieldSchema.description || fieldName,
@@ -320,7 +360,13 @@ export function generateFromSpec(spec, options = {}) {
     if (firstScheme.type === 'http' && firstScheme.scheme === 'bearer') {
       auth = { type: 'bearer', envVar: `${toEnvVar(info.title || 'API')}_TOKEN` };
     } else if (firstScheme.type === 'apiKey') {
-      auth = { type: 'header', header: firstScheme.name || 'X-API-Key', envVar: `${toEnvVar(info.title || 'API')}_KEY` };
+      // Strip CRLF from spec-supplied header name to prevent HTTP response splitting.
+      // A spec with name: "X-API-Key\r\nInjected-Header: evil" would otherwise
+      // write a raw newline into the HTTP header on every outbound call.
+      const rawHeaderName = typeof firstScheme.name === 'string'
+        ? firstScheme.name.replace(/[\r\n]/g, '')
+        : 'X-API-Key';
+      auth = { type: 'header', header: rawHeaderName || 'X-API-Key', envVar: `${toEnvVar(info.title || 'API')}_KEY` };
     } else if (firstScheme.type === 'oauth2') {
       const flows = firstScheme.flows || {};
       const ccFlow = flows.clientCredentials || flows.application;

--- a/src/generate.test.js
+++ b/src/generate.test.js
@@ -288,4 +288,136 @@ describe('generateFromSpec', () => {
     assert.ok(config.tools.some((t) => t.name.includes('list')));
     assert.ok(config.tools.some((t) => t.name.includes('get')));
   });
+
+  it('blocks SSRF — loopback server URL throws', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Evil API', version: '1.0' },
+      servers: [{ url: 'http://127.0.0.1/internal' }],
+      paths: {},
+    };
+    assert.throws(
+      () => generateFromSpec(spec),
+      /loopback|127/i,
+    );
+  });
+
+  it('blocks SSRF — cloud metadata server URL throws', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Evil API', version: '1.0' },
+      servers: [{ url: 'http://169.254.169.254/latest/meta-data' }],
+      paths: {},
+    };
+    assert.throws(
+      () => generateFromSpec(spec),
+      /cloud metadata|169\.254/i,
+    );
+  });
+
+  it('allows private URLs when allowPrivate:true', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Internal API', version: '1.0' },
+      servers: [{ url: 'http://192.168.1.10/api' }],
+      paths: {},
+    };
+    // Should not throw with allowPrivate:true
+    const config = generateFromSpec(spec, { allowPrivate: true });
+    assert.equal(config.baseUrl, 'http://192.168.1.10/api');
+  });
+
+  it('blocks prototype pollution — __proto__ parameter name is dropped', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0' },
+      servers: [{ url: 'https://api.example.com' }],
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'listItems',
+            summary: 'List items',
+            parameters: [
+              { name: '__proto__', in: 'query', schema: { type: 'string' } },
+              { name: 'limit', in: 'query', schema: { type: 'integer' } },
+            ],
+            responses: { 200: { description: 'OK' } },
+          },
+        },
+      },
+    };
+    const config = generateFromSpec(spec);
+    const tool = config.tools.find((t) => t.name === 'list_items');
+    assert.ok(tool, 'list_items tool should exist');
+    // __proto__ should be dropped — must not appear as a property
+    assert.ok(!Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, '__proto__'),
+      '__proto__ key must not appear in properties');
+    // legitimate param should still be present
+    assert.ok(Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, 'limit'),
+      'limit param should survive');
+    // properties should have a null prototype (no inherited keys)
+    assert.equal(Object.getPrototypeOf(tool.inputSchema.properties), null,
+      'properties object must have null prototype');
+  });
+
+  it('blocks prototype pollution — constructor body field is dropped', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0' },
+      servers: [{ url: 'https://api.example.com' }],
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            summary: 'Create item',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      constructor: { type: 'string' },
+                      name: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { 201: { description: 'Created' } },
+          },
+        },
+      },
+    };
+    const config = generateFromSpec(spec);
+    const tool = config.tools.find((t) => t.name === 'create_item');
+    assert.ok(tool, 'create_item tool should exist');
+    assert.ok(!Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, 'constructor'),
+      'constructor key must not appear in properties');
+    assert.ok(Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, 'name'),
+      'name field should survive');
+  });
+
+  it('strips CRLF from apiKey header name', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Injection API', version: '1.0' },
+      servers: [{ url: 'https://api.example.com' }],
+      paths: {},
+      components: {
+        securitySchemes: {
+          apiKey: {
+            type: 'apiKey',
+            name: 'X-API-Key\r\nInjected-Header: evil',
+            in: 'header',
+          },
+        },
+      },
+    };
+    const config = generateFromSpec(spec);
+    assert.ok(config.auth, 'auth should be set');
+    assert.equal(config.auth.type, 'header');
+    assert.ok(!config.auth.header.includes('\r'), 'CR must be stripped from header name');
+    assert.ok(!config.auth.header.includes('\n'), 'LF must be stripped from header name');
+    assert.equal(config.auth.header, 'X-API-KeyInjected-Header: evil');
+  });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `assertSafeUrl()` on the spec-derived `baseUrl` in `generateFromSpec` to block SSRF (loopback, cloud metadata, RFC-1918, link-local) — mirrors `openapi.js:84-89`
- Change `inputSchema.properties` initializer from `{}` to `Object.create(null)` so spec-controlled parameter names (`__proto__`, `constructor`, `prototype`) cannot shadow `Object.prototype` keys — mirrors `openapi.js:287`
- Guard parameter and request-body property writes against `DANGEROUS_KEYS` before each write — mirrors `openapi.js:300-305`
- Apply `sanitizeDescription()` to the tool description field — mirrors `openapi.js:189`
- Strip CR/LF from `firstScheme.name` before assigning to `auth.header` to prevent HTTP response-splitting

## Test plan

- [x] SSRF block: `servers[0].url = "http://127.0.0.1/..."` throws
- [x] SSRF block: `servers[0].url = "http://169.254.169.254/..."` throws
- [x] `allowPrivate: true` bypasses loopback/private block (not metadata)
- [x] Prototype pollution: `__proto__` parameter name is dropped, `properties` has null prototype
- [x] Prototype pollution: `constructor` request body field is dropped
- [x] Header CRLF strip: CR and LF removed from `apiKey` scheme `name` field
- [x] All 25 existing tests continue to pass

Closes #18
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDSK9ovs1zptZn1XZvJuJq)_