### PR TITLE
Constrain frontdoor.*.path fields to working directory

### DIFF
--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -19,7 +19,7 @@
  */
 
 import { readFile, stat } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { BridgeError, BridgeErrorCode } from '../errors.js';
 
 /** Hard ceiling for settings file size. Mirrors MAX_CONFIG_FILE_BYTES. */
@@ -179,9 +179,12 @@ async function fileExists(path) {
  * Validate a parsed settings object.
  *
  * @param {any} settings
+ * @param {object} [opts]
+ * @param {string} [opts.cwd] - Working directory used for path-containment checks (default: process.cwd()).
  * @returns {{ valid: boolean, errors: string[], warnings: string[] }}
  */
-export function validateSettings(settings) {
+export function validateSettings(settings, opts = {}) {
+  const { cwd = process.cwd() } = opts;
   const errors = [];
   const warnings = [];
 
@@ -198,7 +201,7 @@ export function validateSettings(settings) {
 
   if (settings.instance !== undefined) validateInstance(settings.instance, errors);
   if (settings.bridge !== undefined) validateBridge(settings.bridge, errors);
-  if (settings.frontdoor !== undefined) validateFrontdoor(settings.frontdoor, errors, warnings);
+  if (settings.frontdoor !== undefined) validateFrontdoor(settings.frontdoor, errors, warnings, cwd);
 
   return { valid: errors.length === 0, errors, warnings };
 }
@@ -328,7 +331,7 @@ function validateBridgeVault(vault, errors) {
   }
 }
 
-function validateFrontdoor(frontdoor, errors, warnings) {
+function validateFrontdoor(frontdoor, errors, warnings, cwd) {
   if (!isPlainObject(frontdoor)) {
     errors.push('settings.frontdoor must be an object');
     return;
@@ -365,7 +368,7 @@ function validateFrontdoor(frontdoor, errors, warnings) {
   }
   if (frontdoor.surface !== undefined) validateFrontdoorSurface(frontdoor.surface, errors);
   for (const key of ['policy', 'tenantMap', 'steering']) {
-    if (frontdoor[key] !== undefined) validatePathWrapper(frontdoor[key], `settings.frontdoor.${key}`, errors);
+    if (frontdoor[key] !== undefined) validatePathWrapper(frontdoor[key], `settings.frontdoor.${key}`, errors, cwd);
   }
   if (frontdoor.telemetry !== undefined) {
     if (!isPlainObject(frontdoor.telemetry)) {
@@ -494,7 +497,7 @@ function validateTransport(transport, label, errors) {
   }
 }
 
-function validatePathWrapper(value, label, errors) {
+function validatePathWrapper(value, label, errors, cwd) {
   if (!isPlainObject(value)) {
     errors.push(`${label} must be an object`);
     return;
@@ -502,9 +505,33 @@ function validatePathWrapper(value, label, errors) {
   for (const key of Object.keys(value)) {
     if (key !== 'path') errors.push(`${label}: unknown key "${key}"`);
   }
-  if (value.path !== undefined && value.path !== null && typeof value.path !== 'string') {
-    errors.push(`${label}.path must be a string`);
+  if (value.path !== undefined && value.path !== null) {
+    if (typeof value.path !== 'string') {
+      errors.push(`${label}.path must be a string`);
+    } else if (!isPathContained(value.path, cwd)) {
+      errors.push(
+        `${label}.path must be a relative path contained within the working directory (got "${value.path}")`,
+      );
+    }
   }
+}
+
+/**
+ * Return true only when `p` resolves to a path strictly inside `cwd`.
+ * Rejects absolute paths and any path that escapes via `..` traversal.
+ *
+ * @param {string} p   - The path value from settings.
+ * @param {string} cwd - Working directory to treat as the containment root.
+ * @returns {boolean}
+ */
+function isPathContained(p, cwd) {
+  // Reject absolute paths outright — they can target arbitrary locations.
+  if (isAbsolute(p)) return false;
+  const abs = resolve(cwd, p);
+  const rel = relative(cwd, abs);
+  // A safe relative path never starts with '..' and is never empty (which
+  // would mean it equals cwd itself — a directory, not a file).
+  return rel.length > 0 && !rel.startsWith('..');
 }
 
 function hasAnyAuth(auth) {

--- a/src/config/settings.test.js
+++ b/src/config/settings.test.js
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { validateSettings } from './settings.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CWD = '/home/project';
+
+function settingsWithPolicy(pathValue) {
+  return { frontdoor: { policy: { path: pathValue } } };
+}
+
+function settingsWithTenantMap(pathValue) {
+  return { frontdoor: { tenantMap: { path: pathValue } } };
+}
+
+function settingsWithSteering(pathValue) {
+  return { frontdoor: { steering: { path: pathValue } } };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// frontdoor.policy.path — containment checks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validateSettings — frontdoor.*.path containment', () => {
+  // Valid in-repo relative paths
+
+  it('accepts a simple relative path for policy', () => {
+    const result = validateSettings(settingsWithPolicy('config/policy.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a simple relative path for tenantMap', () => {
+    const result = validateSettings(settingsWithTenantMap('config/tenants.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a simple relative path for steering', () => {
+    const result = validateSettings(settingsWithSteering('steering/rules.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a bare filename (no directory segment)', () => {
+    const result = validateSettings(settingsWithPolicy('policy.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a nested relative path', () => {
+    const result = validateSettings(settingsWithPolicy('a/b/c/policy.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  // null / undefined — should remain valid (feature disabled)
+
+  it('accepts null path (feature disabled)', () => {
+    const result = validateSettings(settingsWithPolicy(null), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  // Absolute path rejection
+
+  it('rejects an absolute POSIX path for policy', () => {
+    const result = validateSettings(settingsWithPolicy('/etc/passwd'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((e) => e.includes('settings.frontdoor.policy.path')),
+      `expected policy.path error, got: ${result.errors.join(', ')}`,
+    );
+  });
+
+  it('rejects an absolute path for tenantMap', () => {
+    const result = validateSettings(settingsWithTenantMap('/var/secrets/tenants.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.tenantMap.path')));
+  });
+
+  it('rejects an absolute path for steering', () => {
+    const result = validateSettings(settingsWithSteering('/tmp/steering.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.steering.path')));
+  });
+
+  // Directory-traversal rejection
+
+  it('rejects a simple ../ traversal for policy', () => {
+    const result = validateSettings(settingsWithPolicy('../sibling/policy.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.policy.path')));
+  });
+
+  it('rejects a deep ../ traversal for policy', () => {
+    const result = validateSettings(settingsWithPolicy('../../etc/passwd'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.policy.path')));
+  });
+
+  it('rejects a traversal that descends then escapes', () => {
+    const result = validateSettings(settingsWithPolicy('sub/../../outside'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.policy.path')));
+  });
+
+  it('rejects a traversal for tenantMap', () => {
+    const result = validateSettings(settingsWithTenantMap('../secrets.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.tenantMap.path')));
+  });
+
+  it('rejects a traversal for steering', () => {
+    const result = validateSettings(settingsWithSteering('../steering.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.steering.path')));
+  });
+
+  // Error message quality
+
+  it('includes the offending path value in the error message', () => {
+    const result = validateSettings(settingsWithPolicy('/etc/passwd'), { cwd: CWD });
+    assert.ok(
+      result.errors.some((e) => e.includes('/etc/passwd')),
+      `expected path value in error, got: ${result.errors.join(', ')}`,
+    );
+  });
+
+  it('reports errors for all three fields independently', () => {
+    const result = validateSettings(
+      {
+        frontdoor: {
+          policy: { path: '/etc/policy' },
+          tenantMap: { path: '../../tenants.json' },
+          steering: { path: '/tmp/steering' },
+        },
+      },
+      { cwd: CWD },
+    );
+    assert.equal(result.valid, false);
+    const fields = ['settings.frontdoor.policy.path', 'settings.frontdoor.tenantMap.path', 'settings.frontdoor.steering.path'];
+    for (const field of fields) {
+      assert.ok(
+        result.errors.some((e) => e.includes(field)),
+        `expected error for ${field}, errors: ${result.errors.join(', ')}`,
+      );
+    }
+  });
+});

--- a/test/config/settings.test.js
+++ b/test/config/settings.test.js
@@ -184,7 +184,7 @@ describe('validateSettings — frontdoor', () => {
         network: { allowedOrigins: ['https://example.com'] },
         limits: { sse: { maxConnections: 100, idleTimeoutMs: 60000 } },
         surface: { allowTools: ['a.*'], denyTools: ['b.*'], healthDetail: true },
-        policy: { path: '/etc/policy.json' },
+        policy: { path: 'configs/policy.json' },
         telemetry: { audit: false, events: true },
       },
     });


### PR DESCRIPTION
Closes #21

## Summary

- Add `isPathContained(p, cwd)` helper in `src/config/settings.js` using `isAbsolute` + `relative` from `node:path` to enforce that `frontdoor.{policy,tenantMap,steering}.path` values resolve strictly inside the working directory.
- Reject absolute paths (e.g. `/etc/passwd`) and `..`-traversal paths (e.g. `../../foo`) at settings validation time — before they can reach `loadFrontdoorJson` or `resolve(process.cwd(), ...)` in `cli.js`.
- Thread an optional `{ cwd }` parameter through `validateSettings` → `validateFrontdoor` → `validatePathWrapper` so the check is testable without touching the real filesystem.
- Add `src/config/settings.test.js` with 16 tests: absolute-path rejection, traversal rejection (simple/deep/descend-then-escape), valid in-repo relative paths, null (feature disabled), error message content, and simultaneous errors across all three fields.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDSK9ovs1zptZn1XZvJuJq)_