### PR TITLE
Cap listTools response size; drop oversized callTool raw strings

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -736,6 +736,9 @@ export { sanitizeSpawnEnv as _sanitizeSpawnEnvForTesting };
 // DNS rebinding guard — export the IP validation step for
 // invariant testing without requiring real DNS lookups.
 export { checkResolvedIp as _checkResolvedIpForTesting };
+// buildConnectedServer is exported for unit testing of size-cap logic
+// with mock clients; not part of the public API.
+export { buildConnectedServer as _buildConnectedServerForTesting };
 
 async function buildConnectedServer(client, transport, options) {
   const { prefix, allowlist, blocklist, transforms, policy, source } = options;
@@ -754,6 +757,19 @@ async function buildConnectedServer(client, transport, options) {
 
   // Discover tools from the upstream server
   const listResult = await client.listTools();
+
+  // Guard against memory exhaustion from oversized listTools responses.
+  // An attacker-controlled upstream could return a payload large enough to
+  // exhaust the JSON serialisation budget downstream. Reject before we do
+  // any further work with the result.
+  const listResultJson = JSON.stringify(listResult);
+  if (exceedsJsonParseByteLimit(listResultJson)) {
+    throw new BridgeError(
+      BridgeErrorCode.UPSTREAM_ERROR,
+      `listTools response from "${source}" exceeds the ${MAX_JSON_PARSE_BYTES}-byte size limit and was rejected`,
+    );
+  }
+
   const upstreamTools = listResult.tools || [];
 
   // H15 — validate tool names from upstream before registering them.
@@ -888,13 +904,19 @@ async function buildConnectedServer(client, transport, options) {
           const textContent = result.content.find((c) => c.type === 'text');
           if (textContent) {
             // Guard against memory exhaustion from oversized upstream responses.
-            // Strings larger than 10 MB are returned as-is rather than parsed.
+            // Strings larger than 10 MB are rejected: returning the raw string
+            // would allow callers (e.g. cli.js) to re-serialise it and double
+            // the allocation. Return a structured error object instead so the
+            // raw payload is never propagated further.
             if (exceedsJsonParseByteLimit(textContent.text)) {
               process.stderr.write(
-                `[40mcp] WARNING: upstream tool response exceeds ${MAX_JSON_PARSE_BYTES} bytes — ` +
-                `returning as raw string without JSON.parse\n`,
+                `[40mcp] WARNING: upstream tool response from "${safeLog(source, 128)}" exceeds ${MAX_JSON_PARSE_BYTES} bytes — ` +
+                `response dropped to prevent memory exhaustion\n`,
               );
-              data = textContent.text;
+              data = {
+                error: 'upstream_response_too_large',
+                message: `Tool response from "${source}" exceeded the ${MAX_JSON_PARSE_BYTES}-byte size limit and was dropped`,
+              };
             } else {
               try {
                 data = JSON.parse(textContent.text);

--- a/src/connect.test.js
+++ b/src/connect.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { connectStdio, connectSse, connectMany, connectFromConfig, _sanitizeInputSchemaForTesting as sanitizeInputSchema } from './connect.js';
+import { connectStdio, connectSse, connectMany, connectFromConfig, _sanitizeInputSchemaForTesting as sanitizeInputSchema, _buildConnectedServerForTesting as buildConnectedServer } from './connect.js';
+import { MAX_JSON_PARSE_BYTES } from './connect-size.js';
 
 describe('connectStdio', () => {
   it('throws if command is missing', async () => {
@@ -214,5 +215,96 @@ describe('connectFromConfig', () => {
       { only: ['nonexistent'] }, // Filter out everything
     );
     assert.deepEqual(result.tools, []);
+  });
+});
+
+// ─── size-cap tests ────────────────────────────────────────────────────────
+
+// Helpers to build minimal mock clients for buildConnectedServer unit tests.
+function makeMockTransport() {
+  return { close: async () => {} };
+}
+
+function makeMockClient({ tools = [], callToolResult = null } = {}) {
+  return {
+    initializeResult: { protocolVersion: '2024-11-05' },
+    listTools: async () => ({ tools }),
+    callTool: async () => callToolResult ?? { content: [{ type: 'text', text: '{"ok":true}' }] },
+  };
+}
+
+describe('buildConnectedServer — listTools size cap', () => {
+  it('accepts a listTools response within the byte limit', async () => {
+    const client = makeMockClient({
+      tools: [{ name: 'small_tool', description: 'ok', inputSchema: { type: 'object', properties: {} } }],
+    });
+    const server = await buildConnectedServer(client, makeMockTransport(), { source: 'test-server' });
+    assert.ok(Array.isArray(server.tools));
+    assert.equal(server.tools.length, 1);
+    await server.close();
+  });
+
+  it('rejects a listTools response that exceeds the byte limit', async () => {
+    // Build a tools array whose JSON representation is > MAX_JSON_PARSE_BYTES.
+    // A single tool with a description padded to exceed the cap is sufficient.
+    const hugeDescription = 'x'.repeat(MAX_JSON_PARSE_BYTES + 1);
+    const client = makeMockClient({
+      tools: [{ name: 'big_tool', description: hugeDescription, inputSchema: { type: 'object', properties: {} } }],
+    });
+
+    await assert.rejects(
+      () => buildConnectedServer(client, makeMockTransport(), { source: 'evil-server' }),
+      (err) => {
+        assert.ok(err.message.includes('size limit'), `Expected size-limit message, got: ${err.message}`);
+        return true;
+      },
+    );
+  });
+});
+
+describe('buildConnectedServer — callTool oversized response', () => {
+  it('returns a structured error object (not raw string) when callTool response exceeds the byte limit', async () => {
+    const hugeText = 'y'.repeat(MAX_JSON_PARSE_BYTES + 1);
+    const client = makeMockClient({
+      tools: [{ name: 'streaming_tool', description: 'returns huge payload', inputSchema: { type: 'object', properties: {} } }],
+      callToolResult: { content: [{ type: 'text', text: hugeText }] },
+    });
+
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => { stderrLines.push(String(msg)); return origWrite(msg, ...rest); };
+
+    let result;
+    try {
+      const server = await buildConnectedServer(client, makeMockTransport(), { source: 'big-tool-server' });
+      result = await server.dispatch('streaming_tool', {});
+      await server.close();
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    // Must be a structured error object, NOT the raw oversized string
+    assert.equal(typeof result, 'object', 'Result must be an object, not a raw string');
+    assert.notEqual(result, null);
+    assert.equal(result.error, 'upstream_response_too_large');
+    assert.ok(typeof result.message === 'string');
+
+    // Must have emitted a WARNING to stderr
+    const warned = stderrLines.some((l) => l.includes('WARNING') && (l.includes('exceeds') || l.includes('exceeded')));
+    assert.ok(warned, 'Expected a WARNING message on stderr for oversized response');
+  });
+
+  it('returns parsed JSON normally when callTool response is within the byte limit', async () => {
+    const client = makeMockClient({
+      tools: [{ name: 'normal_tool', description: 'normal', inputSchema: { type: 'object', properties: {} } }],
+      callToolResult: { content: [{ type: 'text', text: JSON.stringify({ answer: 42 }) }] },
+    });
+
+    const server = await buildConnectedServer(client, makeMockTransport(), { source: 'normal-server' });
+    const result = await server.dispatch('normal_tool', {});
+    await server.close();
+
+    assert.equal(typeof result, 'object');
+    assert.equal(result.answer, 42);
   });
 });


### PR DESCRIPTION
## Summary

- Add `MAX_JSON_PARSE_BYTES` guard on `listTools` result in `buildConnectedServer`: stringify the response and throw `BridgeError(UPSTREAM_ERROR)` if it exceeds the cap.
- On `callTool` oversized response, drop the raw string and return a structured error object (`{ error: 'upstream_response_too_large', message: ... }`) instead of propagating the raw payload, which `cli.js:662` would re-`JSON.stringify`, doubling memory.
- Export `_buildConnectedServerForTesting` to enable unit testing with mock clients.
- Add 4 unit tests: oversized `listTools` rejected, oversized `callTool` returns sanitized error (not raw string), both normal-sized cases pass.

## Test plan

- [ ] `node --test src/connect.test.js` — all 21 tests pass (7 suites)
- [ ] Oversized `listTools` test: mock client returns description padded to `MAX_JSON_PARSE_BYTES + 1`; `buildConnectedServer` throws with "size limit" in message
- [ ] Oversized `callTool` test: mock client returns text padded to `MAX_JSON_PARSE_BYTES + 1`; `dispatch` returns `{ error: 'upstream_response_too_large', ... }` object, not the raw string; WARNING written to stderr
- [ ] Normal `callTool` test: response within limit parses JSON as before

Closes #22

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDSK9ovs1zptZn1XZvJuJq)_