### PR TITLE
Security batch: SSE/webhook auth, redirect credential strip, generator guards, and consistency cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ src/
 ├── validate.js      Config validation
 ├── config/          Settings scaffold, show, and mutation helpers
 ├── core/            Client, path interpolation, env guards, types
-├── loaders/         OpenAPI, GraphQL, HAR, plugin registry
+├── loaders/         GraphQL, HAR, plugin registry
 ├── providers/       Provider-level OpenAPI loading
 ├── transforms/      Token-aware response shaping (pick, omit, limit, tokenBudget)
 ├── compose/         Chains (multi-step) + mixer (multi-server)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.1-beta.0
 
-_Released 2026-04-19._
+_Released 2026-04-20._
 
 This marks the beginning of the repo, but it's not the beginning of the story. See [`docs/lineage-note.md`](docs/lineage-note.md) for more detail about why this repo has been given a fresh start for the public repo.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ src/
 ├── errors.js        Structured error taxonomy
 ├── validate.js      Config validation
 ├── core/            Client, path interpolation, types
-├── loaders/         OpenAPI, GraphQL, HAR, plugin registry
+├── loaders/         GraphQL, HAR, plugin registry
 ├── transforms/      Response shaping
 ├── compose/         Chains + mixer
 ├── transport/       Stdio + SSE

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ OAuth2 auto-refreshes tokens with expiry-aware caching and concurrent request co
 40mcp doctor <config>                 Auth / reachability / shape diagnostics
 40mcp vault <sub>                     Sealed-vault ops (init, seal, list,
                                       rotate, rotate-kek, delete, recover, daemon)
+40mcp settings <sub>                  Settings ops (show)
 ```
 
 ## Architecture
@@ -432,8 +433,8 @@ D4: The Tesseract (self-reference + security)
 
 Meta:
 +-- index.d.ts             Full TypeScript declarations
-+-- errors.js              Structured error taxonomy (19 codes)
-+-- cli.js                 14 subcommands
++-- errors.js              Structured error taxonomy (22 codes)
++-- cli.js                 15 subcommands
 
 configs/                   Community configs (see directory for current list)
 +-- github.json            GitHub API
@@ -511,7 +512,7 @@ For AI-assisted contributors: [AGENTS.md](AGENTS.md) covers codebase orientation
 
 ## Integration Guide
 
-Detailed setup for Claude Desktop, Cursor, VS Code, Claude Code, and SSE deployments: [docs/ai-workflow.md](docs/ai-workflow.md)
+Detailed setup for Claude Desktop, Cursor, VS Code, Claude Code, and SSE deployments: [docs/AI_WORKFLOW.md](docs/AI_WORKFLOW.md)
 
 ## Configuration & Operator Docs
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -127,7 +127,7 @@ The reverse bridge (`createReverseBridge`) validates incoming auth headers using
 - 40mcp does not prevent prompt injection by upstream APIs into LLM responses — it controls what reaches the LLM tool call boundary, not what the LLM does with the response.
 - 40mcp's security invariants cover documented code paths. Operator-provided middleware, custom plugins, or extensions are outside this scope.
 
-See [SPEC.md §7](SPEC.md#7-security-model) for the full security model, [docs/SAFE-DEFAULTS.md](docs/SAFE-DEFAULTS.md) for the deployment checklist, [docs/trust-model.md](docs/trust-model.md) for the three-tier trust topology, and [docs/security-evolution.md](docs/security-evolution.md) for the design history behind these controls.
+See [SPEC.md §7](SPEC.md#7-security-model) for the full security model, [docs/SAFE-DEFAULTS.md](docs/SAFE-DEFAULTS.md) for the deployment checklist, [docs/TRUST_MODEL.md](docs/TRUST_MODEL.md) for the three-tier trust topology, and [docs/SECURITY_EVOLUTION.md](docs/SECURITY_EVOLUTION.md) for the design history behind these controls.
 
 ## Security Contacts
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -43,6 +43,7 @@ MCP (Model Context Protocol) is Anthropic's open standard — often called "USB-
 | `init` | Scaffold a starter config interactively |
 | `doctor <config>` | Diagnose a config: auth, reachability, tool-shape checks |
 | `vault <sub>` | Sealed vault ops — `init`, `seal`, `list`, `rotate`, `rotate-kek`, `delete`, `recover`, `daemon` |
+| `settings <sub>` | Settings ops — `show` (display merged settings + env overlays) |
 
 ### Shipped modules (programmatic API)
 
@@ -64,6 +65,7 @@ createReverseBridge()        MCP → REST bridge
 generateOpenApiSpec()        MCP tool set → OpenAPI 3.1 document
 connectStdio()               MCP-to-MCP client (stdio)
 connectSse()                 MCP-to-MCP client (SSE)
+connectStreamableHttp()      MCP-to-MCP client (Streamable HTTP)
 connectFromConfig()          MCP-to-MCP client (from .mcp.json)
 connectMany()                Multi-server MCP aggregator
 createWebhookListener()      HTTP webhook → tool dispatch

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@emulators/github": "^0.4.1",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.19.17",
         "emulate": "^0.4.1",
         "eslint": "^10.2.0"
       },
@@ -279,9 +279,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "devDependencies": {
     "@emulators/github": "^0.4.1",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.17",
     "emulate": "^0.4.1",
     "eslint": "^10.2.0"
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@
  * 40mcp inspect config.json # List tools without starting
  */
 
-import { readFile, writeFile, access } from 'node:fs/promises';
+import { readFile, writeFile, access, stat } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { homedir, platform } from 'node:os';
@@ -37,6 +37,9 @@ import { generateFromSpec, generatePrompt } from './generate.js';
 import { connectStdio, connectFromConfig } from './connect.js';
 import { loadSettings, pick, parseByteSize } from './config/settings.js';
 import { setTelemetryConfig, setInstanceMetadata, instanceBannerSuffix } from './core/events.js';
+
+/** Hard ceiling for frontdoor JSON file size. Mirrors MAX_CONFIG_FILE_BYTES in config.js. */
+const MAX_FRONTDOOR_FILE_BYTES = 16 * 1024 * 1024;
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -983,6 +986,15 @@ function positionalArgs(args) {
 async function loadFrontdoorJson(flagValue, flagName) {
  if (flagValue === undefined || flagValue === false) return null;
  const filePath = resolve(process.cwd(), String(flagValue));
+ let st;
+ try {
+ st = await stat(filePath);
+ } catch (err) {
+ fatal(`${flagName} ${filePath}: ${err.message}`);
+ }
+ if (st.size > MAX_FRONTDOOR_FILE_BYTES) {
+ fatal(`${flagName} ${filePath}: file too large (${st.size} > ${MAX_FRONTDOOR_FILE_BYTES} bytes).`);
+ }
  let raw;
  try {
  raw = await readFile(filePath, 'utf-8');

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -1,0 +1,105 @@
+/**
+ * Tests for cli.js — currently focused on loadFrontdoorJson file-size cap.
+ *
+ * loadFrontdoorJson is not exported (cli.js is a runnable script), so
+ * coverage is achieved via subprocess: spawn `node src/cli.js serve` with a
+ * valid minimal config and a --policy file that is slightly over the 16 MiB
+ * limit.  The process must exit 1 and emit the "file too large" diagnostic to
+ * stderr.
+ */
+
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, unlinkSync, mkdirSync, rmdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = resolve(__dirname, 'cli.js');
+
+/** 16 MiB — must match MAX_FRONTDOOR_FILE_BYTES in cli.js. */
+const MAX_FRONTDOOR_FILE_BYTES = 16 * 1024 * 1024;
+
+// ─── Temp-file helpers ────────────────────────────────────────────────────────
+
+const createdFiles = [];
+const createdDirs = [];
+
+function tmpFile(name, content) {
+  const filePath = join(tmpdir(), `cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}-${name}`);
+  writeFileSync(filePath, content);
+  createdFiles.push(filePath);
+  return filePath;
+}
+
+after(() => {
+  for (const f of createdFiles) {
+    try { unlinkSync(f); } catch {}
+  }
+  for (const d of createdDirs) {
+    try { rmdirSync(d); } catch {}
+  }
+});
+
+// ─── loadFrontdoorJson size-cap ───────────────────────────────────────────────
+
+describe('loadFrontdoorJson — file-size cap', () => {
+  it('rejects a --policy file that exceeds the 16 MiB limit', () => {
+    // Minimal valid config that loadConfig will accept.
+    const configPath = tmpFile('config.json', JSON.stringify({
+      tools: [],
+      servers: [],
+    }));
+
+    // Policy file slightly above the cap: MAX + 1 byte.
+    // Fill with spaces so JSON.parse would succeed if the cap weren't present.
+    const oversize = MAX_FRONTDOOR_FILE_BYTES + 1;
+    // Construct: leading whitespace (ignored by JSON.parse) + valid JSON object.
+    // We use a Buffer of spaces followed by "{}" to stay valid JSON while
+    // exceeding the size limit.
+    const policyBuf = Buffer.alloc(oversize, 0x20); // 0x20 = space
+    // Overwrite last two bytes with '{}'
+    policyBuf[oversize - 2] = 0x7b; // '{'
+    policyBuf[oversize - 1] = 0x7d; // '}'
+    const policyPath = tmpFile('policy.json', policyBuf);
+
+    const result = spawnSync(process.execPath, [CLI_PATH, 'serve', configPath, '--policy', policyPath], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
+
+    assert.strictEqual(result.status, 1, `Expected exit code 1, got ${result.status}`);
+    assert.ok(
+      result.stderr.includes('file too large'),
+      `Expected stderr to contain "file too large", got: ${result.stderr}`,
+    );
+  });
+
+  it('accepts a --policy file at exactly the 16 MiB limit', () => {
+    const configPath = tmpFile('config.json', JSON.stringify({
+      tools: [],
+      servers: [],
+    }));
+
+    // File at exactly the cap should not be rejected by the size check.
+    // It will be rejected later (not a valid JSON object with meaningful
+    // content) — but the process must NOT exit with "file too large".
+    const atLimit = MAX_FRONTDOOR_FILE_BYTES;
+    const policyBuf = Buffer.alloc(atLimit, 0x20);
+    policyBuf[atLimit - 2] = 0x7b; // '{'
+    policyBuf[atLimit - 1] = 0x7d; // '}'
+    const policyPath = tmpFile('policy-exact.json', policyBuf);
+
+    const result = spawnSync(process.execPath, [CLI_PATH, 'serve', configPath, '--policy', policyPath], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
+
+    assert.ok(
+      !result.stderr.includes('file too large'),
+      `Unexpected "file too large" for at-limit file. stderr: ${result.stderr}`,
+    );
+  });
+});

--- a/src/cli.test.js
+++ b/src/cli.test.js
@@ -11,7 +11,7 @@
 import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { writeFileSync, unlinkSync, mkdirSync, rmdirSync } from 'node:fs';
+import { writeFileSync, unlinkSync, rmdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/src/config/settings.js
+++ b/src/config/settings.js
@@ -19,7 +19,7 @@
  */
 
 import { readFile, stat } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { BridgeError, BridgeErrorCode } from '../errors.js';
 
 /** Hard ceiling for settings file size. Mirrors MAX_CONFIG_FILE_BYTES. */
@@ -179,9 +179,12 @@ async function fileExists(path) {
  * Validate a parsed settings object.
  *
  * @param {any} settings
+ * @param {object} [opts]
+ * @param {string} [opts.cwd] - Working directory used for path-containment checks (default: process.cwd()).
  * @returns {{ valid: boolean, errors: string[], warnings: string[] }}
  */
-export function validateSettings(settings) {
+export function validateSettings(settings, opts = {}) {
+  const { cwd = process.cwd() } = opts;
   const errors = [];
   const warnings = [];
 
@@ -198,7 +201,7 @@ export function validateSettings(settings) {
 
   if (settings.instance !== undefined) validateInstance(settings.instance, errors);
   if (settings.bridge !== undefined) validateBridge(settings.bridge, errors);
-  if (settings.frontdoor !== undefined) validateFrontdoor(settings.frontdoor, errors, warnings);
+  if (settings.frontdoor !== undefined) validateFrontdoor(settings.frontdoor, errors, warnings, cwd);
 
   return { valid: errors.length === 0, errors, warnings };
 }
@@ -328,7 +331,7 @@ function validateBridgeVault(vault, errors) {
   }
 }
 
-function validateFrontdoor(frontdoor, errors, warnings) {
+function validateFrontdoor(frontdoor, errors, warnings, cwd) {
   if (!isPlainObject(frontdoor)) {
     errors.push('settings.frontdoor must be an object');
     return;
@@ -365,7 +368,7 @@ function validateFrontdoor(frontdoor, errors, warnings) {
   }
   if (frontdoor.surface !== undefined) validateFrontdoorSurface(frontdoor.surface, errors);
   for (const key of ['policy', 'tenantMap', 'steering']) {
-    if (frontdoor[key] !== undefined) validatePathWrapper(frontdoor[key], `settings.frontdoor.${key}`, errors);
+    if (frontdoor[key] !== undefined) validatePathWrapper(frontdoor[key], `settings.frontdoor.${key}`, errors, cwd);
   }
   if (frontdoor.telemetry !== undefined) {
     if (!isPlainObject(frontdoor.telemetry)) {
@@ -494,7 +497,7 @@ function validateTransport(transport, label, errors) {
   }
 }
 
-function validatePathWrapper(value, label, errors) {
+function validatePathWrapper(value, label, errors, cwd) {
   if (!isPlainObject(value)) {
     errors.push(`${label} must be an object`);
     return;
@@ -502,9 +505,33 @@ function validatePathWrapper(value, label, errors) {
   for (const key of Object.keys(value)) {
     if (key !== 'path') errors.push(`${label}: unknown key "${key}"`);
   }
-  if (value.path !== undefined && value.path !== null && typeof value.path !== 'string') {
-    errors.push(`${label}.path must be a string`);
+  if (value.path !== undefined && value.path !== null) {
+    if (typeof value.path !== 'string') {
+      errors.push(`${label}.path must be a string`);
+    } else if (!isPathContained(value.path, cwd)) {
+      errors.push(
+        `${label}.path must be a relative path contained within the working directory (got "${value.path}")`,
+      );
+    }
   }
+}
+
+/**
+ * Return true only when `p` resolves to a path strictly inside `cwd`.
+ * Rejects absolute paths and any path that escapes via `..` traversal.
+ *
+ * @param {string} p   - The path value from settings.
+ * @param {string} cwd - Working directory to treat as the containment root.
+ * @returns {boolean}
+ */
+function isPathContained(p, cwd) {
+  // Reject absolute paths outright — they can target arbitrary locations.
+  if (isAbsolute(p)) return false;
+  const abs = resolve(cwd, p);
+  const rel = relative(cwd, abs);
+  // A safe relative path never starts with '..' and is never empty (which
+  // would mean it equals cwd itself — a directory, not a file).
+  return rel.length > 0 && !rel.startsWith('..');
 }
 
 function hasAnyAuth(auth) {

--- a/src/config/settings.test.js
+++ b/src/config/settings.test.js
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { validateSettings } from './settings.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CWD = '/home/project';
+
+function settingsWithPolicy(pathValue) {
+  return { frontdoor: { policy: { path: pathValue } } };
+}
+
+function settingsWithTenantMap(pathValue) {
+  return { frontdoor: { tenantMap: { path: pathValue } } };
+}
+
+function settingsWithSteering(pathValue) {
+  return { frontdoor: { steering: { path: pathValue } } };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// frontdoor.policy.path — containment checks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validateSettings — frontdoor.*.path containment', () => {
+  // Valid in-repo relative paths
+
+  it('accepts a simple relative path for policy', () => {
+    const result = validateSettings(settingsWithPolicy('config/policy.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a simple relative path for tenantMap', () => {
+    const result = validateSettings(settingsWithTenantMap('config/tenants.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a simple relative path for steering', () => {
+    const result = validateSettings(settingsWithSteering('steering/rules.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a bare filename (no directory segment)', () => {
+    const result = validateSettings(settingsWithPolicy('policy.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  it('accepts a nested relative path', () => {
+    const result = validateSettings(settingsWithPolicy('a/b/c/policy.json'), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  // null / undefined — should remain valid (feature disabled)
+
+  it('accepts null path (feature disabled)', () => {
+    const result = validateSettings(settingsWithPolicy(null), { cwd: CWD });
+    assert.equal(result.valid, true, `unexpected errors: ${result.errors.join(', ')}`);
+  });
+
+  // Absolute path rejection
+
+  it('rejects an absolute POSIX path for policy', () => {
+    const result = validateSettings(settingsWithPolicy('/etc/passwd'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(
+      result.errors.some((e) => e.includes('settings.frontdoor.policy.path')),
+      `expected policy.path error, got: ${result.errors.join(', ')}`,
+    );
+  });
+
+  it('rejects an absolute path for tenantMap', () => {
+    const result = validateSettings(settingsWithTenantMap('/var/secrets/tenants.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.tenantMap.path')));
+  });
+
+  it('rejects an absolute path for steering', () => {
+    const result = validateSettings(settingsWithSteering('/tmp/steering.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.steering.path')));
+  });
+
+  // Directory-traversal rejection
+
+  it('rejects a simple ../ traversal for policy', () => {
+    const result = validateSettings(settingsWithPolicy('../sibling/policy.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.policy.path')));
+  });
+
+  it('rejects a deep ../ traversal for policy', () => {
+    const result = validateSettings(settingsWithPolicy('../../etc/passwd'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.policy.path')));
+  });
+
+  it('rejects a traversal that descends then escapes', () => {
+    const result = validateSettings(settingsWithPolicy('sub/../../outside'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.policy.path')));
+  });
+
+  it('rejects a traversal for tenantMap', () => {
+    const result = validateSettings(settingsWithTenantMap('../secrets.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.tenantMap.path')));
+  });
+
+  it('rejects a traversal for steering', () => {
+    const result = validateSettings(settingsWithSteering('../steering.json'), { cwd: CWD });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some((e) => e.includes('settings.frontdoor.steering.path')));
+  });
+
+  // Error message quality
+
+  it('includes the offending path value in the error message', () => {
+    const result = validateSettings(settingsWithPolicy('/etc/passwd'), { cwd: CWD });
+    assert.ok(
+      result.errors.some((e) => e.includes('/etc/passwd')),
+      `expected path value in error, got: ${result.errors.join(', ')}`,
+    );
+  });
+
+  it('reports errors for all three fields independently', () => {
+    const result = validateSettings(
+      {
+        frontdoor: {
+          policy: { path: '/etc/policy' },
+          tenantMap: { path: '../../tenants.json' },
+          steering: { path: '/tmp/steering' },
+        },
+      },
+      { cwd: CWD },
+    );
+    assert.equal(result.valid, false);
+    const fields = ['settings.frontdoor.policy.path', 'settings.frontdoor.tenantMap.path', 'settings.frontdoor.steering.path'];
+    for (const field of fields) {
+      assert.ok(
+        result.errors.some((e) => e.includes(field)),
+        `expected error for ${field}, errors: ${result.errors.join(', ')}`,
+      );
+    }
+  });
+});

--- a/src/config/settings.test.js
+++ b/src/config/settings.test.js
@@ -1,6 +1,5 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { join } from 'node:path';
 import { validateSettings } from './settings.js';
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/connect.js
+++ b/src/connect.js
@@ -736,6 +736,9 @@ export { sanitizeSpawnEnv as _sanitizeSpawnEnvForTesting };
 // DNS rebinding guard — export the IP validation step for
 // invariant testing without requiring real DNS lookups.
 export { checkResolvedIp as _checkResolvedIpForTesting };
+// buildConnectedServer is exported for unit testing of size-cap logic
+// with mock clients; not part of the public API.
+export { buildConnectedServer as _buildConnectedServerForTesting };
 
 async function buildConnectedServer(client, transport, options) {
   const { prefix, allowlist, blocklist, transforms, policy, source } = options;
@@ -754,6 +757,19 @@ async function buildConnectedServer(client, transport, options) {
 
   // Discover tools from the upstream server
   const listResult = await client.listTools();
+
+  // Guard against memory exhaustion from oversized listTools responses.
+  // An attacker-controlled upstream could return a payload large enough to
+  // exhaust the JSON serialisation budget downstream. Reject before we do
+  // any further work with the result.
+  const listResultJson = JSON.stringify(listResult);
+  if (exceedsJsonParseByteLimit(listResultJson)) {
+    throw new BridgeError(
+      BridgeErrorCode.UPSTREAM_ERROR,
+      `listTools response from "${source}" exceeds the ${MAX_JSON_PARSE_BYTES}-byte size limit and was rejected`,
+    );
+  }
+
   const upstreamTools = listResult.tools || [];
 
   // H15 — validate tool names from upstream before registering them.
@@ -888,13 +904,19 @@ async function buildConnectedServer(client, transport, options) {
           const textContent = result.content.find((c) => c.type === 'text');
           if (textContent) {
             // Guard against memory exhaustion from oversized upstream responses.
-            // Strings larger than 10 MB are returned as-is rather than parsed.
+            // Strings larger than 10 MB are rejected: returning the raw string
+            // would allow callers (e.g. cli.js) to re-serialise it and double
+            // the allocation. Return a structured error object instead so the
+            // raw payload is never propagated further.
             if (exceedsJsonParseByteLimit(textContent.text)) {
               process.stderr.write(
-                `[40mcp] WARNING: upstream tool response exceeds ${MAX_JSON_PARSE_BYTES} bytes — ` +
-                `returning as raw string without JSON.parse\n`,
+                `[40mcp] WARNING: upstream tool response from "${safeLog(source, 128)}" exceeds ${MAX_JSON_PARSE_BYTES} bytes — ` +
+                `response dropped to prevent memory exhaustion\n`,
               );
-              data = textContent.text;
+              data = {
+                error: 'upstream_response_too_large',
+                message: `Tool response from "${source}" exceeded the ${MAX_JSON_PARSE_BYTES}-byte size limit and was dropped`,
+              };
             } else {
               try {
                 data = JSON.parse(textContent.text);

--- a/src/connect.test.js
+++ b/src/connect.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { connectStdio, connectSse, connectMany, connectFromConfig, _sanitizeInputSchemaForTesting as sanitizeInputSchema } from './connect.js';
+import { connectStdio, connectSse, connectMany, connectFromConfig, _sanitizeInputSchemaForTesting as sanitizeInputSchema, _buildConnectedServerForTesting as buildConnectedServer } from './connect.js';
+import { MAX_JSON_PARSE_BYTES } from './connect-size.js';
 
 describe('connectStdio', () => {
   it('throws if command is missing', async () => {
@@ -214,5 +215,96 @@ describe('connectFromConfig', () => {
       { only: ['nonexistent'] }, // Filter out everything
     );
     assert.deepEqual(result.tools, []);
+  });
+});
+
+// ─── size-cap tests ────────────────────────────────────────────────────────
+
+// Helpers to build minimal mock clients for buildConnectedServer unit tests.
+function makeMockTransport() {
+  return { close: async () => {} };
+}
+
+function makeMockClient({ tools = [], callToolResult = null } = {}) {
+  return {
+    initializeResult: { protocolVersion: '2024-11-05' },
+    listTools: async () => ({ tools }),
+    callTool: async () => callToolResult ?? { content: [{ type: 'text', text: '{"ok":true}' }] },
+  };
+}
+
+describe('buildConnectedServer — listTools size cap', () => {
+  it('accepts a listTools response within the byte limit', async () => {
+    const client = makeMockClient({
+      tools: [{ name: 'small_tool', description: 'ok', inputSchema: { type: 'object', properties: {} } }],
+    });
+    const server = await buildConnectedServer(client, makeMockTransport(), { source: 'test-server' });
+    assert.ok(Array.isArray(server.tools));
+    assert.equal(server.tools.length, 1);
+    await server.close();
+  });
+
+  it('rejects a listTools response that exceeds the byte limit', async () => {
+    // Build a tools array whose JSON representation is > MAX_JSON_PARSE_BYTES.
+    // A single tool with a description padded to exceed the cap is sufficient.
+    const hugeDescription = 'x'.repeat(MAX_JSON_PARSE_BYTES + 1);
+    const client = makeMockClient({
+      tools: [{ name: 'big_tool', description: hugeDescription, inputSchema: { type: 'object', properties: {} } }],
+    });
+
+    await assert.rejects(
+      () => buildConnectedServer(client, makeMockTransport(), { source: 'evil-server' }),
+      (err) => {
+        assert.ok(err.message.includes('size limit'), `Expected size-limit message, got: ${err.message}`);
+        return true;
+      },
+    );
+  });
+});
+
+describe('buildConnectedServer — callTool oversized response', () => {
+  it('returns a structured error object (not raw string) when callTool response exceeds the byte limit', async () => {
+    const hugeText = 'y'.repeat(MAX_JSON_PARSE_BYTES + 1);
+    const client = makeMockClient({
+      tools: [{ name: 'streaming_tool', description: 'returns huge payload', inputSchema: { type: 'object', properties: {} } }],
+      callToolResult: { content: [{ type: 'text', text: hugeText }] },
+    });
+
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => { stderrLines.push(String(msg)); return origWrite(msg, ...rest); };
+
+    let result;
+    try {
+      const server = await buildConnectedServer(client, makeMockTransport(), { source: 'big-tool-server' });
+      result = await server.dispatch('streaming_tool', {});
+      await server.close();
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    // Must be a structured error object, NOT the raw oversized string
+    assert.equal(typeof result, 'object', 'Result must be an object, not a raw string');
+    assert.notEqual(result, null);
+    assert.equal(result.error, 'upstream_response_too_large');
+    assert.ok(typeof result.message === 'string');
+
+    // Must have emitted a WARNING to stderr
+    const warned = stderrLines.some((l) => l.includes('WARNING') && (l.includes('exceeds') || l.includes('exceeded')));
+    assert.ok(warned, 'Expected a WARNING message on stderr for oversized response');
+  });
+
+  it('returns parsed JSON normally when callTool response is within the byte limit', async () => {
+    const client = makeMockClient({
+      tools: [{ name: 'normal_tool', description: 'normal', inputSchema: { type: 'object', properties: {} } }],
+      callToolResult: { content: [{ type: 'text', text: JSON.stringify({ answer: 42 }) }] },
+    });
+
+    const server = await buildConnectedServer(client, makeMockTransport(), { source: 'normal-server' });
+    const result = await server.dispatch('normal_tool', {});
+    await server.close();
+
+    assert.equal(typeof result, 'object');
+    assert.equal(result.answer, 42);
   });
 });

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -493,6 +493,13 @@ export function createApiClient(baseUrl, authConfig, hooks) {
       response = await fetch(url, init);
       // Manual redirect loop — bounded at 5 hops.
       let hops = 0;
+      // Once a credential header is stripped due to a cross-origin redirect,
+      // it must stay stripped for every subsequent hop — even if a later hop
+      // is same-origin with its predecessor. Otherwise rebuilding `redirectInit`
+      // from the original `init.headers` on each iteration silently
+      // re-introduces the credential after the trust boundary was already
+      // crossed (issue #17 follow-up).
+      const persistentlyStrippedHeaders = new Set();
       while (
         response &&
         (response.type === 'opaqueredirect' ||
@@ -572,10 +579,18 @@ export function createApiClient(baseUrl, authConfig, hooks) {
           catch { return false; }
         })();
         if (!sameOrigin) {
+          persistentlyStrippedHeaders.add('authorization');
+          persistentlyStrippedHeaders.add('cookie');
+          persistentlyStrippedHeaders.add('proxy-authorization');
+        }
+        // Apply persistent strips on every hop, regardless of this hop's
+        // same-origin status. A header that was stripped on an earlier
+        // cross-origin hop must not be re-introduced from `init.headers` by
+        // a later same-origin hop.
+        if (persistentlyStrippedHeaders.size > 0) {
           redirectInit.headers = { ...(init.headers || {}) };
           for (const k of Object.keys(redirectInit.headers)) {
-            const lk = k.toLowerCase();
-            if (lk === 'authorization' || lk === 'cookie' || lk === 'proxy-authorization') {
+            if (persistentlyStrippedHeaders.has(k.toLowerCase())) {
               delete redirectInit.headers[k];
             }
           }

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -486,6 +486,9 @@ export function createApiClient(baseUrl, authConfig, hooks) {
     }
 
     let response;
+    // Track the URL of the most-recently-fetched hop so that relative
+    // Location headers on subsequent hops resolve correctly (issue #20).
+    let currentUrl = url;
     try {
       response = await fetch(url, init);
       // Manual redirect loop — bounded at 5 hops.
@@ -519,7 +522,10 @@ export function createApiClient(baseUrl, authConfig, hooks) {
         }
         let nextUrl;
         try {
-          nextUrl = new URL(loc, url).toString();
+          // Resolve against currentUrl (the previous hop's URL) so that
+          // relative Location headers on multi-hop chains work correctly
+          // instead of always resolving against the original request URL (#20).
+          nextUrl = new URL(loc, currentUrl).toString();
         } catch {
           throw new ApiError(
             BridgeErrorCode.API_NETWORK,
@@ -559,6 +565,24 @@ export function createApiClient(baseUrl, authConfig, hooks) {
           redirectInit.method = 'GET';
           delete redirectInit.body;
         }
+        // Strip credential headers on cross-origin redirects (issue #17).
+        // Browsers do this per the Fetch spec; Node's fetch does not.
+        const sameOrigin = (() => {
+          try { return new URL(nextUrl).origin === new URL(currentUrl).origin; }
+          catch { return false; }
+        })();
+        if (!sameOrigin) {
+          redirectInit.headers = { ...(init.headers || {}) };
+          for (const k of Object.keys(redirectInit.headers)) {
+            const lk = k.toLowerCase();
+            if (lk === 'authorization' || lk === 'cookie' || lk === 'proxy-authorization') {
+              delete redirectInit.headers[k];
+            }
+          }
+        }
+        // Update currentUrl before fetching the next hop so that the next
+        // iteration resolves relative Locations correctly (#20).
+        currentUrl = nextUrl;
         response = await fetch(nextUrl, redirectInit);
       }
     } catch (err) {

--- a/src/core/client.test.js
+++ b/src/core/client.test.js
@@ -736,7 +736,7 @@ describe('redirect security', () => {
   it('resolves relative Location on second hop against first hop URL, not original URL', async () => {
     const fetchCalls = [];
 
-    globalThis.fetch = async (url, init) => {
+    globalThis.fetch = async (url, _init) => {
       fetchCalls.push(url);
 
       if (url === 'https://api.example.com/start') {

--- a/src/core/client.test.js
+++ b/src/core/client.test.js
@@ -585,3 +585,200 @@ describe('API client (created by createApiClient)', () => {
     assert.equal(capturedInit.body, JSON.stringify({ modified: true }));
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Redirect security tests (issues #17 and #20)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('redirect security', () => {
+  // Issue #17: Authorization (and other credential headers) must be stripped
+  // when a redirect crosses origins, matching the browser Fetch spec behavior.
+  it('strips Authorization header on cross-origin 307 redirect', async () => {
+    const fetchCalls = [];
+
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url, headers: { ...init.headers } });
+
+      if (url === 'https://api.example.com/resource') {
+        // First fetch: respond with a 307 redirect to a different origin
+        return {
+          type: 'basic',
+          status: 307,
+          headers: {
+            get: (name) => name === 'location' ? 'https://other.example.com/resource' : null,
+          },
+        };
+      }
+      // Second fetch (cross-origin target): return 200
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '{"ok":true}',
+      };
+    };
+
+    process.env.TEST_AUTH_TOKEN = 'secret-bearer-token';
+    try {
+      const client = createApiClient('https://api.example.com', {
+        type: 'bearer',
+        envVar: 'TEST_AUTH_TOKEN',
+      }, { allowPrivateRedirect: false });
+
+      await assert.rejects(
+        () => client('GET', '/resource'),
+        // assertSafeUrl will block other.example.com as a public host only when
+        // allowPrivateRedirect is false — but the key assertion is on headers
+        // below. Use a broad matcher so the test passes on any error shape.
+        () => true,
+      );
+    } catch {
+      // ignore errors from assertSafeUrl; we only care about the headers check
+    } finally {
+      delete process.env.TEST_AUTH_TOKEN;
+    }
+
+    // The second fetch call must NOT carry Authorization
+    assert.ok(fetchCalls.length >= 2, 'Expected at least two fetch calls (original + redirect)');
+    const redirectCall = fetchCalls[1];
+    assert.ok(
+      !Object.keys(redirectCall.headers).some(k => k.toLowerCase() === 'authorization'),
+      `Authorization header must be stripped on cross-origin redirect, got headers: ${JSON.stringify(Object.keys(redirectCall.headers))}`,
+    );
+  });
+
+  it('strips Cookie and Proxy-Authorization on cross-origin redirect', async () => {
+    const fetchCalls = [];
+
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url, headers: { ...init.headers } });
+
+      if (url === 'https://api.example.com/resource') {
+        return {
+          type: 'basic',
+          status: 302,
+          headers: {
+            get: (name) => name === 'location' ? 'https://cdn.other.com/resource' : null,
+          },
+        };
+      }
+      return { ok: true, status: 200, text: async () => '{}' };
+    };
+
+    // Manually craft a client and inject Cookie + Proxy-Authorization via beforeRequest
+    const client = createApiClient('https://api.example.com', null, {
+      beforeRequest: async () => ({
+        headers: {
+          'Cookie': 'session=abc',
+          'Proxy-Authorization': 'Basic xyz',
+        },
+      }),
+    });
+
+    try {
+      await client('GET', '/resource');
+    } catch {
+      // May fail on assertSafeUrl; the header assertion is what matters
+    }
+
+    assert.ok(fetchCalls.length >= 2, 'Expected redirect to trigger second fetch');
+    const redirectHeaders = fetchCalls[1].headers;
+    assert.ok(
+      !Object.keys(redirectHeaders).some(k => k.toLowerCase() === 'cookie'),
+      'Cookie must be stripped on cross-origin redirect',
+    );
+    assert.ok(
+      !Object.keys(redirectHeaders).some(k => k.toLowerCase() === 'proxy-authorization'),
+      'Proxy-Authorization must be stripped on cross-origin redirect',
+    );
+  });
+
+  it('preserves Authorization header on same-origin redirect', async () => {
+    const fetchCalls = [];
+
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url, headers: { ...init.headers } });
+
+      if (url === 'https://api.example.com/old-path') {
+        return {
+          type: 'basic',
+          status: 301,
+          headers: {
+            get: (name) => name === 'location' ? 'https://api.example.com/new-path' : null,
+          },
+        };
+      }
+      return { ok: true, status: 200, text: async () => '{}' };
+    };
+
+    process.env.SAME_ORIGIN_TOKEN = 'same-origin-secret';
+    try {
+      const client = createApiClient('https://api.example.com', {
+        type: 'bearer',
+        envVar: 'SAME_ORIGIN_TOKEN',
+      });
+      await client('GET', '/old-path');
+    } finally {
+      delete process.env.SAME_ORIGIN_TOKEN;
+    }
+
+    assert.ok(fetchCalls.length >= 2, 'Expected redirect to trigger second fetch');
+    // On 301 the method downgrades to GET so body is dropped, but Authorization
+    // must still be present because the origin is the same.
+    const redirectHeaders = fetchCalls[1].headers;
+    assert.ok(
+      Object.keys(redirectHeaders).some(k => k.toLowerCase() === 'authorization'),
+      `Authorization must be preserved on same-origin redirect, got: ${JSON.stringify(Object.keys(redirectHeaders))}`,
+    );
+  });
+
+  // Issue #20: multi-hop redirect chains where the second Location is relative
+  // must resolve against the previous hop's URL, not the original request URL.
+  it('resolves relative Location on second hop against first hop URL, not original URL', async () => {
+    const fetchCalls = [];
+
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push(url);
+
+      if (url === 'https://api.example.com/start') {
+        // Hop 1: redirect to a completely different origin
+        return {
+          type: 'basic',
+          status: 302,
+          headers: {
+            get: (name) => name === 'location' ? 'https://cdn.example.com/base/' : null,
+          },
+        };
+      }
+      if (url === 'https://cdn.example.com/base/') {
+        // Hop 2: relative redirect — should resolve against https://cdn.example.com/base/
+        return {
+          type: 'basic',
+          status: 301,
+          headers: {
+            get: (name) => name === 'location' ? 'final' : null,
+          },
+        };
+      }
+      // Final destination
+      return { ok: true, status: 200, text: async () => '{"arrived":true}' };
+    };
+
+    // We bypass assertSafeUrl by allowing private redirects; cdn.example.com is
+    // public so it will be allowed by default, but allowPrivateRedirect: true
+    // ensures no unexpected rejection.
+    const client = createApiClient('https://api.example.com', null, {
+      allowPrivateRedirect: true,
+    });
+
+    await client('GET', '/start');
+
+    assert.ok(fetchCalls.length >= 3, `Expected 3 fetch calls, got ${fetchCalls.length}: ${fetchCalls.join(', ')}`);
+    // The relative 'final' on hop 2 must resolve against https://cdn.example.com/base/
+    // yielding https://cdn.example.com/base/final, NOT https://api.example.com/final.
+    assert.equal(
+      fetchCalls[2],
+      'https://cdn.example.com/base/final',
+      `Third fetch must resolve relative Location against hop-1 URL. Got: ${fetchCalls[2]}`,
+    );
+  });
+});

--- a/src/core/client.test.js
+++ b/src/core/client.test.js
@@ -781,4 +781,72 @@ describe('redirect security', () => {
       `Third fetch must resolve relative Location against hop-1 URL. Got: ${fetchCalls[2]}`,
     );
   });
+
+  // Issue #17 follow-up (PR #37 review): once a credential header has been
+  // stripped due to a cross-origin redirect, it must NOT be reintroduced by a
+  // subsequent same-origin redirect. Otherwise multi-hop chains can resurrect
+  // Authorization on the 2nd foreign hop, defeating the strip.
+  it('does not reintroduce stripped credentials on subsequent same-origin hops', async () => {
+    const fetchCalls = [];
+
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url, headers: { ...(init?.headers || {}) } });
+
+      if (url === 'https://api.example.com/start') {
+        // Hop 0 (initial) → cross-origin redirect to cdn.example.com
+        return {
+          type: 'basic',
+          status: 302,
+          headers: {
+            get: (name) => name === 'location' ? 'https://cdn.example.com/intermediate' : null,
+          },
+        };
+      }
+      if (url === 'https://cdn.example.com/intermediate') {
+        // Hop 1 → SAME-ORIGIN redirect, still on cdn.example.com.
+        // The bug: this hop would re-include Authorization because the
+        // strip branch only fires when sameOrigin is false.
+        return {
+          type: 'basic',
+          status: 302,
+          headers: {
+            get: (name) => name === 'location' ? 'https://cdn.example.com/final' : null,
+          },
+        };
+      }
+      // Final destination
+      return { ok: true, status: 200, text: async () => '{"arrived":true}' };
+    };
+
+    const client = createApiClient('https://api.example.com', {
+      type: 'bearer',
+      value: 'super-secret-token',
+    }, { allowPrivateRedirect: true });
+
+    await client('GET', '/start');
+
+    assert.ok(fetchCalls.length >= 3, `Expected 3 fetch calls, got ${fetchCalls.length}`);
+
+    // Hop 0 to api.example.com — Authorization MUST be present (origin matches).
+    const hop0 = fetchCalls[0].headers;
+    assert.ok(
+      Object.keys(hop0).some(k => k.toLowerCase() === 'authorization'),
+      `Hop 0 (api.example.com) must carry Authorization. Got: ${JSON.stringify(Object.keys(hop0))}`,
+    );
+
+    // Hop 1 to cdn.example.com — Authorization MUST be stripped (cross-origin).
+    const hop1 = fetchCalls[1].headers;
+    assert.ok(
+      !Object.keys(hop1).some(k => k.toLowerCase() === 'authorization'),
+      `Hop 1 (cdn.example.com, cross-origin) must NOT carry Authorization. Got: ${JSON.stringify(Object.keys(hop1))}`,
+    );
+
+    // Hop 2 to cdn.example.com/final — same-origin to hop 1, but credential
+    // was already stripped at the trust boundary and MUST stay stripped.
+    const hop2 = fetchCalls[2].headers;
+    assert.ok(
+      !Object.keys(hop2).some(k => k.toLowerCase() === 'authorization'),
+      `Hop 2 (same-origin to hop 1) must NOT reintroduce Authorization. Got: ${JSON.stringify(Object.keys(hop2))}`,
+    );
+  });
 });

--- a/src/generate.js
+++ b/src/generate.js
@@ -10,6 +10,9 @@
 
 import { validateConfig } from './validate.js';
 import { toSnakeCase } from './core/path.js';
+import { assertSafeUrl } from './core/env.js';
+import { sanitizeDescription } from './core/sanitize.js';
+import { DANGEROUS_KEYS } from './core/object.js';
 
 /**
  * The system prompt that teaches an LLM how to generate 40mcp configs.
@@ -221,6 +224,18 @@ export function generateFromSpec(spec, options = {}) {
   const info = spec.info || {};
   const servers = spec.servers || [];
   const baseUrl = servers[0]?.url || '';
+
+  // SSRF guard: validate spec-derived base URL against the same policy used by
+  // openapi.js. A spec with servers[0].url = "http://169.254.169.254/..." would
+  // otherwise cause every dispatched tool call to hit cloud metadata or other
+  // internal infrastructure. Only validate when the spec actually supplies a URL.
+  if (baseUrl) {
+    assertSafeUrl(baseUrl, {
+      allowPrivate: options.allowPrivate === true,
+      label: 'generateFromSpec server url',
+    });
+  }
+
   const paths = spec.paths || {};
 
   const tools = [];
@@ -235,10 +250,19 @@ export function generateFromSpec(spec, options = {}) {
 
       const tool = {
         name,
-        description: operation.summary || operation.description || `${httpMethod} ${pathTemplate}`,
+        // Sanitize description: spec-supplied summary/description fields flow into
+        // the LLM tool list verbatim. Run through the prompt-injection scanner and
+        // replace matches with a neutral placeholder. Mirrors openapi.js:188-189.
+        description: sanitizeDescription(
+          operation.summary || operation.description || `${httpMethod} ${pathTemplate}`,
+          { label: 'generateFromSpec' },
+        ),
         method: httpMethod,
         path: pathTemplate.replace(/\{([^}]+)\}/g, ':$1'),
-        inputSchema: { type: 'object', properties: {}, required: [] },
+        // Use null-prototype object so spec-controlled parameter names (e.g.
+        // "__proto__", "constructor") cannot shadow Object.prototype keys.
+        // Mirrors openapi.js parametersToSchema (openapi.js:287).
+        inputSchema: { type: 'object', properties: Object.create(null), required: [] },
       };
 
       // Extract parameters
@@ -246,7 +270,16 @@ export function generateFromSpec(spec, options = {}) {
       const queryMap = {};
 
       for (const param of params) {
+        if (!param || !param.name) continue;
         const propName = toSnakeCase(param.name);
+        // Drop any parameter whose converted name collides with a reserved
+        // JS object key. Mirrors openapi.js parametersToSchema:300-305.
+        if (DANGEROUS_KEYS.has(propName)) {
+          process.stderr.write(
+            `[40mcp] generateFromSpec: dropped parameter "${param.name}" — reserved JS object key\n`,
+          );
+          continue;
+        }
         tool.inputSchema.properties[propName] = {
           type: param.schema?.type || 'string',
           description: param.description || param.name,
@@ -273,6 +306,13 @@ export function generateFromSpec(spec, options = {}) {
           const bodyMap = {};
           for (const [fieldName, fieldSchema] of Object.entries(content.schema.properties)) {
             const propName = toSnakeCase(fieldName);
+            // Drop reserved JS object keys. Mirrors openapi.js parametersToSchema:300-305.
+            if (DANGEROUS_KEYS.has(propName)) {
+              process.stderr.write(
+                `[40mcp] generateFromSpec: dropped body field "${fieldName}" — reserved JS object key\n`,
+              );
+              continue;
+            }
             tool.inputSchema.properties[propName] = {
               type: fieldSchema.type || 'string',
               description: fieldSchema.description || fieldName,
@@ -320,7 +360,13 @@ export function generateFromSpec(spec, options = {}) {
     if (firstScheme.type === 'http' && firstScheme.scheme === 'bearer') {
       auth = { type: 'bearer', envVar: `${toEnvVar(info.title || 'API')}_TOKEN` };
     } else if (firstScheme.type === 'apiKey') {
-      auth = { type: 'header', header: firstScheme.name || 'X-API-Key', envVar: `${toEnvVar(info.title || 'API')}_KEY` };
+      // Strip CRLF from spec-supplied header name to prevent HTTP response splitting.
+      // A spec with name: "X-API-Key\r\nInjected-Header: evil" would otherwise
+      // write a raw newline into the HTTP header on every outbound call.
+      const rawHeaderName = typeof firstScheme.name === 'string'
+        ? firstScheme.name.replace(/[\r\n]/g, '')
+        : 'X-API-Key';
+      auth = { type: 'header', header: rawHeaderName || 'X-API-Key', envVar: `${toEnvVar(info.title || 'API')}_KEY` };
     } else if (firstScheme.type === 'oauth2') {
       const flows = firstScheme.flows || {};
       const ccFlow = flows.clientCredentials || flows.application;

--- a/src/generate.test.js
+++ b/src/generate.test.js
@@ -288,4 +288,136 @@ describe('generateFromSpec', () => {
     assert.ok(config.tools.some((t) => t.name.includes('list')));
     assert.ok(config.tools.some((t) => t.name.includes('get')));
   });
+
+  it('blocks SSRF — loopback server URL throws', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Evil API', version: '1.0' },
+      servers: [{ url: 'http://127.0.0.1/internal' }],
+      paths: {},
+    };
+    assert.throws(
+      () => generateFromSpec(spec),
+      /loopback|127/i,
+    );
+  });
+
+  it('blocks SSRF — cloud metadata server URL throws', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Evil API', version: '1.0' },
+      servers: [{ url: 'http://169.254.169.254/latest/meta-data' }],
+      paths: {},
+    };
+    assert.throws(
+      () => generateFromSpec(spec),
+      /cloud metadata|169\.254/i,
+    );
+  });
+
+  it('allows private URLs when allowPrivate:true', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Internal API', version: '1.0' },
+      servers: [{ url: 'http://192.168.1.10/api' }],
+      paths: {},
+    };
+    // Should not throw with allowPrivate:true
+    const config = generateFromSpec(spec, { allowPrivate: true });
+    assert.equal(config.baseUrl, 'http://192.168.1.10/api');
+  });
+
+  it('blocks prototype pollution — __proto__ parameter name is dropped', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0' },
+      servers: [{ url: 'https://api.example.com' }],
+      paths: {
+        '/items': {
+          get: {
+            operationId: 'listItems',
+            summary: 'List items',
+            parameters: [
+              { name: '__proto__', in: 'query', schema: { type: 'string' } },
+              { name: 'limit', in: 'query', schema: { type: 'integer' } },
+            ],
+            responses: { 200: { description: 'OK' } },
+          },
+        },
+      },
+    };
+    const config = generateFromSpec(spec);
+    const tool = config.tools.find((t) => t.name === 'list_items');
+    assert.ok(tool, 'list_items tool should exist');
+    // __proto__ should be dropped — must not appear as a property
+    assert.ok(!Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, '__proto__'),
+      '__proto__ key must not appear in properties');
+    // legitimate param should still be present
+    assert.ok(Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, 'limit'),
+      'limit param should survive');
+    // properties should have a null prototype (no inherited keys)
+    assert.equal(Object.getPrototypeOf(tool.inputSchema.properties), null,
+      'properties object must have null prototype');
+  });
+
+  it('blocks prototype pollution — constructor body field is dropped', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0' },
+      servers: [{ url: 'https://api.example.com' }],
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            summary: 'Create item',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      constructor: { type: 'string' },
+                      name: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { 201: { description: 'Created' } },
+          },
+        },
+      },
+    };
+    const config = generateFromSpec(spec);
+    const tool = config.tools.find((t) => t.name === 'create_item');
+    assert.ok(tool, 'create_item tool should exist');
+    assert.ok(!Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, 'constructor'),
+      'constructor key must not appear in properties');
+    assert.ok(Object.prototype.hasOwnProperty.call(tool.inputSchema.properties, 'name'),
+      'name field should survive');
+  });
+
+  it('strips CRLF from apiKey header name', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Injection API', version: '1.0' },
+      servers: [{ url: 'https://api.example.com' }],
+      paths: {},
+      components: {
+        securitySchemes: {
+          apiKey: {
+            type: 'apiKey',
+            name: 'X-API-Key\r\nInjected-Header: evil',
+            in: 'header',
+          },
+        },
+      },
+    };
+    const config = generateFromSpec(spec);
+    assert.ok(config.auth, 'auth should be set');
+    assert.equal(config.auth.type, 'header');
+    assert.ok(!config.auth.header.includes('\r'), 'CR must be stripped from header name');
+    assert.ok(!config.auth.header.includes('\n'), 'LF must be stripped from header name');
+    assert.equal(config.auth.header, 'X-API-KeyInjected-Header: evil');
+  });
 });

--- a/src/transport/sse.js
+++ b/src/transport/sse.js
@@ -482,6 +482,23 @@ export async function createSseTransport(server, options = {}) {
  return;
  }
 
+ // Cross-principal ownership check: in multi-token mode, verify that the
+ // bearer principal who authenticated this POST owns the target session.
+ // Single-token mode (both null) is a no-op.
+ if (transport._frontdoorPrincipal !== null &&
+     postAuth.principal !== null &&
+     postAuth.principal !== transport._frontdoorPrincipal) {
+ emitEvent('sse.cross_principal_denied', {
+ sessionId,
+ sessionPrincipal: transport._frontdoorPrincipal,
+ requestPrincipal: postAuth.principal,
+ clientIp: req.socket.remoteAddress || 'unknown',
+ });
+ res.writeHead(403);
+ res.end('Forbidden');
+ return;
+ }
+
  // Enforce a per-request socket timeout ONLY on message POSTs
  // (not the long-lived GET /sse stream). A slow
  // POST that drips body bytes to stay under the idle timer would

--- a/src/transport/transport.test.js
+++ b/src/transport/transport.test.js
@@ -377,6 +377,146 @@ describe('SSE transport — multi-token bearer auth', () => {
   });
 });
 
+describe('SSE transport — cross-principal session ownership', () => {
+  // Use a noop stub to support multiple concurrent sessions.
+  function createMultiSessionStub() {
+    return { connect: async () => {} };
+  }
+
+  it('POST /message returns 403 when bearer principal does not own the session', async () => {
+    // Configure two principals: alice and bob.
+    const server = createMultiSessionStub();
+    const { httpServer } = await createSseTransport(server, {
+      port: 0,
+      requireBearer: { alice: 'tok-a', bob: 'tok-b' },
+      maxSessionsPerIp: 100,
+    });
+
+    const ctls = [];
+    try {
+      const port = httpServer.address().port;
+
+      // Open a session as alice.
+      const aliceCtl = new AbortController();
+      ctls.push(aliceCtl);
+      const aliceRes = await fetch(`http://127.0.0.1:${port}/sse?sessionId=alice-sess`, {
+        headers: { Authorization: 'Bearer tok-a' },
+        signal: aliceCtl.signal,
+      });
+      assert.notEqual(aliceRes.status, 401, 'alice SSE connect should not 401');
+
+      // Read the initial SSE event to get the sessionId echoed back; we
+      // already know it's "alice-sess" since we supplied it explicitly.
+      // Give the handler a tick to register the session.
+      await new Promise((done) => setTimeout(done, 50));
+
+      // Bob tries to POST a message to alice's session — must be denied.
+      const crossRes = await fetch(
+        `http://127.0.0.1:${port}/message?sessionId=alice-sess`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer tok-b',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+        },
+      );
+      await crossRes.text().catch(() => {});
+      assert.equal(crossRes.status, 403, 'cross-principal POST should be denied with 403');
+    } finally {
+      for (const c of ctls) c.abort();
+      httpServer.close();
+    }
+  });
+
+  it('POST /message succeeds when bearer principal owns the session', async () => {
+    const server = createMultiSessionStub();
+    const { httpServer } = await createSseTransport(server, {
+      port: 0,
+      requireBearer: { alice: 'tok-a', bob: 'tok-b' },
+      maxSessionsPerIp: 100,
+    });
+
+    const ctls = [];
+    try {
+      const port = httpServer.address().port;
+
+      // Open alice's session.
+      const aliceCtl = new AbortController();
+      ctls.push(aliceCtl);
+      const aliceRes = await fetch(`http://127.0.0.1:${port}/sse?sessionId=alice-own`, {
+        headers: { Authorization: 'Bearer tok-a' },
+        signal: aliceCtl.signal,
+      });
+      assert.notEqual(aliceRes.status, 401, 'alice SSE connect should not 401');
+
+      await new Promise((done) => setTimeout(done, 50));
+
+      // Alice POSTs to her own session — must not get 403.
+      const ownRes = await fetch(
+        `http://127.0.0.1:${port}/message?sessionId=alice-own`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer tok-a',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+        },
+      );
+      await ownRes.text().catch(() => {});
+      assert.notEqual(ownRes.status, 403, 'same-principal POST must not be 403');
+    } finally {
+      for (const c of ctls) c.abort();
+      httpServer.close();
+    }
+  });
+
+  it('single-token mode allows any valid token to POST to any session', async () => {
+    // In single-token mode both postAuth.principal and _frontdoorPrincipal
+    // are null, so the ownership gate is a no-op — no 403 should fire.
+    const server = createMultiSessionStub();
+    const { httpServer } = await createSseTransport(server, {
+      port: 0,
+      requireBearer: 'shared-tok',
+      maxSessionsPerIp: 100,
+    });
+
+    const ctls = [];
+    try {
+      const port = httpServer.address().port;
+
+      const sessCtl = new AbortController();
+      ctls.push(sessCtl);
+      const sessRes = await fetch(`http://127.0.0.1:${port}/sse?sessionId=single-sess`, {
+        headers: { Authorization: 'Bearer shared-tok' },
+        signal: sessCtl.signal,
+      });
+      assert.notEqual(sessRes.status, 401, 'single-token SSE connect should not 401');
+
+      await new Promise((done) => setTimeout(done, 50));
+
+      const postRes = await fetch(
+        `http://127.0.0.1:${port}/message?sessionId=single-sess`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer shared-tok',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+        },
+      );
+      await postRes.text().catch(() => {});
+      assert.notEqual(postRes.status, 403, 'single-token mode must not 403');
+    } finally {
+      for (const c of ctls) c.abort();
+      httpServer.close();
+    }
+  });
+});
+
 describe('SSE transport — per-principal session cap', () => {
   // The real MCP SDK `Server` rejects a second `connect(transport)` call
   // — fine for production (one Server per process) but it makes

--- a/src/webhook/listener.js
+++ b/src/webhook/listener.js
@@ -326,12 +326,27 @@ export function createWebhookListener(config) {
   }
 
   // Validate routes
+  // A01: mirror the reverse-bridge guard — hard-error on non-loopback routes
+  // without a secret; warn on loopback routes without a secret.
+  const bindHost = host;
+  const isLoopback = bindHost === '127.0.0.1' || bindHost === 'localhost' || bindHost === '::1';
+
   for (const route of routes) {
     if (!route.path || !SAFE_PATH_PATTERN.test(route.path)) {
       throw new BridgeError(BridgeErrorCode.CONFIG_INVALID, `Invalid webhook route path: "${route.path}"`);
     }
     if (!route.tool) {
       throw new BridgeError(BridgeErrorCode.CONFIG_MISSING_FIELD, `Webhook route ${route.path} requires a tool name`);
+    }
+    if (!route.secret) {
+      if (!isLoopback) {
+        throw new BridgeError(
+          BridgeErrorCode.CONFIG_INVALID,
+          `[${name}] Webhook route "${route.path}" has no secret configured but the listener is bound to non-loopback host "${bindHost}". ` +
+          `Set route.secret or bind to 127.0.0.1.`,
+        );
+      }
+      process.stderr.write(`[${name}] WARNING: webhook route "${route.path}" has no secret — all requests will be dispatched unauthenticated\n`);
     }
   }
 
@@ -539,7 +554,12 @@ export function createWebhookListener(config) {
     if (route.response !== 'sync') {
       res.setHeader('Content-Type', 'application/json');
       res.writeHead(202);
-      res.end(JSON.stringify({ status: 'accepted', tool: route.tool }));
+      // Omit the tool name on routes without a secret to reduce recon surface —
+      // an unauthenticated caller learns nothing about which tool is being dispatched.
+      const accepted202 = route.secret
+        ? { status: 'accepted', tool: route.tool }
+        : { status: 'accepted' };
+      res.end(JSON.stringify(accepted202));
 
       // Fire and forget — rate-limited error logging to prevent log flooding
       dispatch(route.tool, args)

--- a/src/webhook/listener.test.js
+++ b/src/webhook/listener.test.js
@@ -100,6 +100,82 @@ describe('createWebhookListener', () => {
       (err) => err.message.includes('requires a tool name'),
     );
   });
+
+  // ─── A01: non-loopback host without secret is a hard error ───────────────
+
+  it('throws when a route has no secret and host is 0.0.0.0', () => {
+    assert.throws(
+      () => createWebhookListener({
+        dispatch: async () => {},
+        host: '0.0.0.0',
+        routes: [{ path: '/hook', tool: 'test' }],
+      }),
+      (err) => err.message.includes('no secret') || err.message.includes('Set route.secret'),
+    );
+  });
+
+  it('throws when a route has no secret and host is a non-loopback IP', () => {
+    assert.throws(
+      () => createWebhookListener({
+        dispatch: async () => {},
+        host: '10.0.0.1',
+        routes: [{ path: '/hook', tool: 'test' }],
+      }),
+      (err) => err.message.includes('Set route.secret'),
+    );
+  });
+
+  it('does NOT throw when a route has no secret and host is 127.0.0.1 (loopback)', () => {
+    const stderrLines = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => { stderrLines.push(String(msg)); return origWrite(msg, ...rest); };
+    try {
+      assert.doesNotThrow(
+        () => createWebhookListener({
+          dispatch: async () => {},
+          host: '127.0.0.1',
+          routes: [{ path: '/hook', tool: 'test' }],
+        }),
+      );
+      // A warning must be emitted for the unauthenticated loopback route
+      assert.ok(
+        stderrLines.some((l) => l.includes('WARNING') && l.includes('no secret')),
+        'Expected a WARNING stderr line about the missing secret',
+      );
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('does NOT throw when a route has no secret and host is localhost (loopback)', () => {
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => origWrite(msg, ...rest);
+    try {
+      assert.doesNotThrow(
+        () => createWebhookListener({
+          dispatch: async () => {},
+          host: 'localhost',
+          routes: [{ path: '/hook', tool: 'test' }],
+        }),
+      );
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('does NOT throw when a route HAS a secret and host is 0.0.0.0', () => {
+    assert.doesNotThrow(
+      () => createWebhookListener({
+        dispatch: async () => {},
+        host: '0.0.0.0',
+        routes: [{
+          path: '/hook',
+          tool: 'test',
+          secret: { type: 'header', envVar: '__TEST_WEBHOOK_SECRET' },
+        }],
+      }),
+    );
+  });
 });
 
 describe('webhook HTTP server', () => {
@@ -475,6 +551,69 @@ describe('webhook HTTP server', () => {
   });
 
   // ─── Async error rate limiter tests ──────────────────────────────────
+
+  // ─── 202 recon-reduction: tool field is omitted on no-secret routes ─────
+
+  it('202 response omits tool name on loopback routes without a secret', async () => {
+    const dispatch = createMockDispatch();
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg, ...rest) => origWrite(msg, ...rest); // suppress warning noise in test output
+
+    try {
+      const listener = createWebhookListener({
+        dispatch,
+        port: 0,
+        host: '127.0.0.1',
+        routes: [{ path: '/hooks/test', tool: 'my_tool' }],
+      });
+      const { httpServer, url } = await listener.start();
+
+      try {
+        const res = await sendRequest(url, '/hooks/test', { body: { event: 'push' } });
+        assert.equal(res.status, 202);
+        const body = await res.json();
+        assert.equal(body.status, 'accepted');
+        assert.equal(body.tool, undefined, '202 must not echo tool name on no-secret routes (recon reduction)');
+      } finally {
+        httpServer.close();
+      }
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it('202 response includes tool name on routes with a secret', async () => {
+    const dispatch = createMockDispatch();
+    process.env.__TEST_WEBHOOK_SECRET202 = 'secret-for-202-test';
+
+    try {
+      const listener = createWebhookListener({
+        dispatch,
+        port: 0,
+        routes: [{
+          path: '/hooks/test',
+          tool: 'my_tool',
+          secret: { type: 'header', header: 'x-webhook-secret', envVar: '__TEST_WEBHOOK_SECRET202' },
+        }],
+      });
+      const { httpServer, url } = await listener.start();
+
+      try {
+        const res = await sendRequest(url, '/hooks/test', {
+          body: {},
+          headers: { 'x-webhook-secret': 'secret-for-202-test' },
+        });
+        assert.equal(res.status, 202);
+        const body = await res.json();
+        assert.equal(body.status, 'accepted');
+        assert.equal(body.tool, 'my_tool', '202 must include tool name when route has a secret');
+      } finally {
+        httpServer.close();
+      }
+    } finally {
+      delete process.env.__TEST_WEBHOOK_SECRET202;
+    }
+  });
 
   it('suppresses repeated async dispatch errors after rate limit is reached', async () => {
     let dispatchCallCount = 0;

--- a/test/bridge-microsoft-huggingface.test.js
+++ b/test/bridge-microsoft-huggingface.test.js
@@ -392,8 +392,11 @@ describe('Live probe (skipped when offline): real remote MCP endpoints', () => {
         connected = await connectStreamableHttp({ url: target.url, prefix: target.prefix });
       } catch (err) {
         const msg = String(err?.message || err);
+        const code = err?.code;
         const networkBlocked =
-          /ENETUNREACH|ECONNREFUSED|EAI_AGAIN|ENOTFOUND|fetch failed|403|tunnel|proxy|(?:SSE|Streamable HTTP) client transport not available/i.test(msg);
+          /ENETUNREACH|ECONNREFUSED|EAI_AGAIN|ENOTFOUND|fetch failed|403|not in allowlist|tunnel|proxy|(?:SSE|Streamable HTTP) client transport not available/i.test(msg) ||
+          code === 403 ||
+          code === 'ENETUNREACH' || code === 'ECONNREFUSED' || code === 'EAI_AGAIN' || code === 'ENOTFOUND';
         if (networkBlocked) {
           process.stderr.write(`[live-probe] ${target.label}: skipped (offline / egress blocked): ${msg.split('\n')[0]}\n`);
           return;

--- a/test/config/settings.test.js
+++ b/test/config/settings.test.js
@@ -184,7 +184,7 @@ describe('validateSettings — frontdoor', () => {
         network: { allowedOrigins: ['https://example.com'] },
         limits: { sse: { maxConnections: 100, idleTimeoutMs: 60000 } },
         surface: { allowTools: ['a.*'], denyTools: ['b.*'], healthDetail: true },
-        policy: { path: '/etc/policy.json' },
+        policy: { path: 'configs/policy.json' },
         telemetry: { audit: false, events: true },
       },
     });


### PR DESCRIPTION
Batch of security fixes and consistency cleanup, surfaced by an audit pass. Each item below was implemented on its own feature branch, CI-verified across the full matrix (Node 18/20/22 on Ubuntu, Node 22 on macOS, lint, smoke), reviewed by an independent agent, and squash-merged into this subbranch.

## Real blockers (security)

| # | Commit | What it fixes |
|---|---|---|
| #15 | `0d93aaf` | SSE multi-token: cross-principal session injection on `POST /message`. Ownership check now runs after `sessions.get(sessionId)` and emits `sse.cross_principal_denied` audit event before the 403. Single-token mode unchanged. |
| #16 | `ca2beef` | Webhook routes without `secret` no longer accept unauthenticated dispatch on non-loopback hosts. Hard-errors at `createWebhookListener` construction; loopback routes get a startup WARNING; 202 response drops `tool` field on no-secret routes. |
| #17 | `54c1536` | `Authorization`, `Cookie`, and `Proxy-Authorization` are now stripped from `redirectInit` when the next hop's origin differs (matches the Fetch spec; Node's `fetch` doesn't do this automatically). |
| #18 | `03b8df6` | `generateFromSpec` now applies the same SSRF (`assertSafeUrl`), prototype-pollution (`Object.create(null)` + `DANGEROUS_KEYS` filter), description sanitization, and CRLF strip that the parallel `openapi.js` path already enforces. |
| #19 | `67c4113` | `loadFrontdoorJson` now stat-and-caps the input file (16 MB, matching the sibling loaders). Closes the `--policy /dev/zero` OOM. |

## Should-fixes (security)

| # | Commit | What it fixes |
|---|---|---|
| #20 | `54c1536` | (combined with #17) Multi-hop relative `Location` now resolves against the previous hop's URL, not the original. |
| #21 | `f86bfa3` | `frontdoor.{policy,tenantMap,steering}.path` fields now must resolve inside `cwd`. Absolute paths and `..`-traversal rejected at validation time. |
| #22 | `ff4a54d` | `listTools` response size capped via `MAX_JSON_PARSE_BYTES`; oversized `callTool` responses now return a structured error instead of the raw string (which `cli.js` was re-stringifying). |

## Consistency / docs

| # | Commit | What it fixes |
|---|---|---|
| #23, #24 | `100fc71` | Broken case-mismatched doc links; subcommand count (14 → 15), error code count (19 → 22), CHANGELOG release date (2026-04-19 → 2026-04-20), `loaders/` architecture-map cleanup, `settings` and `connectStreamableHttp` added to CLI reference + SPEC §2. |
| #26 | `efeeacb` | `@types/node` bumped from `^20` to `^22` to match the highest Node version exercised in CI. |

## Closes

Closes #15
Closes #16
Closes #17
Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
Closes #26

## Out of scope (still open)

- **#25** (`engines.node` vs ESLint 10.x mismatch) — needs your decision among options A/B/C in the issue body.
- **#27** (Add Windows job to CI matrix) — adding the job is mechanical, but Windows tests are likely to surface platform-specific bugs in vault path handling and settings allowlist that need oversight to triage rather than autonomous fixing.

## Verification

- 9 separate sub-PRs (#28–#36), each ran the full CI matrix.
- One CI failure surfaced and was fixed in-flight: PR #35 hit a pre-existing test in `test/config/settings.test.js` that used `/etc/policy.json` as a placeholder; the new containment check correctly rejects absolute paths, so the fixture was updated to a contained path (`configs/policy.json`).
- Each PR independently reviewed by a sonnet review agent; review comments posted on each sub-PR.
- No `package.json` version bump in this batch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDSK9ovs1zptZn1XZvJuJq)_