### PR TITLE
Docs: lead with the operator's decision tree, demote the tesseract narrative

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -2,6 +2,8 @@
 
 > A 40verse project. The name is not a version number.
 
+> **This is a design-philosophy essay — the *why*, not the *how*.** It explains the geometric model behind 40mcp's architecture and why the capabilities are layered the way they are. It is not a usage guide. If you are here to decide which command to run, start with the [README decision tree](README.md#which-command-do-i-run); for the normative contract, see [SPEC.md](SPEC.md). The geometry language below (line, plane, cube, tesseract) lives here and only here.
+
 ---
 
 ## Why This Exists

--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ Both upstream configs are public, require no credentials, and stay inside the MC
 
 ---
 
+## Which command do I run?
+
+Start here. Pick the row that matches what you have and what you want — each command links to the deeper docs.
+
+| You have… | …and you want to | Run | You want this when… |
+|-----------|------------------|-----|---------------------|
+| One API (config, spec, or endpoint) | Expose it as MCP tools | [`serve`](docs/BRIDGE_VS_FRONTDOOR.md#bridge-40mcp-serve) | You have a single API and just need it callable by an agent. |
+| Many MCP servers already running | Front them behind one authenticated surface | [`link`](docs/BRIDGE_VS_FRONTDOOR.md#frontdoor-40mcp-link) | You have several upstream MCP servers and want one namespace and one auth boundary. See [FRONTDOOR.md](docs/FRONTDOOR.md) to publish it over SSE. |
+| Many REST configs | Combine them into one MCP server | [`mix`](SPEC.md#2-10-scope) | You have multiple REST APIs and want them in a single tool surface (no separate auth boundary). |
+| MCP tools you want as plain HTTP | Expose MCP tools as a REST API | [`reverse`](SPEC.md#2-10-scope) | A non-MCP client needs to call your tools over REST (plus an auto-generated OpenAPI spec). |
+| An undocumented API (browser traffic) | Generate tools from a recording | [`from-har`](#from-browser-traffic-no-spec) | The API has no spec — you only have captured HTTP traffic. |
+| A documented API (OpenAPI/Swagger) | Generate tools from the spec | [`from-openapi`](#from-an-openapi-spec) | You have an OpenAPI 3.x or Swagger 2.x document. |
+| A GraphQL endpoint | Generate tools by introspection | [`from-graphql`](#input-type-reference) | You have a GraphQL endpoint that supports introspection. |
+
+> **One API → `serve`. Many MCP upstreams → `link`. Many REST configs → `mix`.** That covers most decisions. For the full `serve`-vs-`link` mental model, see [docs/BRIDGE_VS_FRONTDOOR.md](docs/BRIDGE_VS_FRONTDOOR.md).
+
+---
+
 ## Install
 
 ```bash
@@ -399,23 +417,23 @@ OAuth2 auto-refreshes tokens with expiry-aware caching and concurrent request co
 
 ## Architecture
 
-Modules mapped to dimensions:
+Modules grouped by responsibility:
 
 ```
-D1: The Line (core bridge)
+Core bridge
 +-- bridge.js              Dispatch engine
 +-- core/client.js         API client (auth, OAuth2, timeout)
 +-- core/path.js           URL interpolation, query strings
 +-- transport/             stdio + SSE
 
-D2: The Plane (loaders + discovery)
+Loaders + discovery
 +-- openapi.js             OpenAPI 3.x + Swagger 2.x
 +-- loaders/graphql.js     GraphQL introspection
 +-- loaders/har.js         HAR traffic recording
 +-- loaders/registry.js    Plugin system + auto-detection
 +-- generate.js            AI-assisted config generation
 
-D3: The Cube (composition + shaping)
+Composition + shaping
 +-- compose/chain.js       Compound chains (depth-guarded)
 +-- compose/mixer.js       Multi-server mixing
 +-- transforms/response.js Token-aware response shaping
@@ -423,7 +441,7 @@ D3: The Cube (composition + shaping)
 +-- webhook/listener.js    Webhook ingestion
 +-- tenant/scope.js        Multi-tenant scoping
 
-D4: The Tesseract (self-reference + security)
+Self-reference + security
 +-- reverse/server.js      MCP -> REST (+ auto OpenAPI spec)
 +-- security/vault.js      Sealed credential vault (envelope encryption)
 +-- security/policy.js     Human-in-the-loop gates
@@ -446,9 +464,7 @@ configs/                   Community configs (see directory for current list)
 
 One dependency: `@modelcontextprotocol/sdk`. All other functionality uses Node builtins. Full TypeScript via `.d.ts`.
 
-## The Tesseract
-
-40mcp models its architecture as a tesseract — four nested dimensions where each folds the previous into itself. For the conceptual framing behind the D1–D4 architecture (why each dimension is a structural transformation, not a feature list), see [CONCEPT.md](CONCEPT.md).
+> The four groups above map to the D1–D4 design model in [CONCEPT.md](CONCEPT.md) — read that for the *why*, not the *how*.
 
 ## Local Development Without API Keys
 
@@ -521,6 +537,10 @@ Detailed setup for Claude Desktop, Cursor, VS Code, Claude Code, and SSE deploym
 - [docs/COMMANDS/settings-and-doctor.md](docs/COMMANDS/settings-and-doctor.md) — `settings show` and `doctor` scope
 - [docs/FRONTDOOR.md](docs/FRONTDOOR.md) — published SSE deployment patterns
 - [docs/TESTING.md](docs/TESTING.md) — operator testing strategy for bridges, frontdoors, tenants, and policy gates
+
+## Design philosophy
+
+- [CONCEPT.md](CONCEPT.md) — the design-philosophy essay behind the D1–D4 architecture (the *why*, not the *how*). For day-to-day usage, start with the [decision tree](#which-command-do-i-run) above.
 
 ## License
 

--- a/docs/BRIDGE_VS_FRONTDOOR.md
+++ b/docs/BRIDGE_VS_FRONTDOOR.md
@@ -1,5 +1,7 @@
 # Bridge vs Frontdoor
 
+> **New here?** Start with the [README decision tree](../README.md#which-command-do-i-run) to pick a command, then come back for the full `serve`-vs-`link` mental model.
+
 Two shapes, two commands, two clusters in `40mcp.settings.json`. Knowing which applies when is the single most important mental model in 40mcp.
 
 ---


### PR DESCRIPTION
Closes #46.

**Stacked on #48** (steering removal) — merge #48 first; this PR's base is that branch so the diff stays scoped. Documentation only; no source changes.

The mental model an operator actually needs — *when do I `serve` vs `link` vs `mix` vs `reverse`?* — was scattered across README, BRIDGE_VS_FRONTDOOR.md, and FRONTDOOR.md while CONCEPT.md's geometry essay sat front and center.

## Changes

**README.md**
- New **"Which command do I run?"** decision-tree table right after the 60-second golden path: `serve`, `link`, `mix`, `reverse`, `from-har`, `from-openapi`, `from-graphql` — each with a one-line "you want this when…" cue and links into the deeper docs, closed with the serve/link/mix rule of thumb.
- Architecture module map relabeled from "D1: The Line … D4: The Tesseract" to plain responsibility groups (Core bridge / Loaders + discovery / Composition + shaping / Self-reference + security); the standalone Tesseract section is now a one-line pointer to CONCEPT.md.
- "Design philosophy" entry added to Further reading (bottom) linking CONCEPT.md.

**CONCEPT.md**
- Preface added reframing the doc as the design-philosophy essay — the *why*, not the *how* — directing usage to the README decision tree and the contract to SPEC.md. No content deleted.

**docs/BRIDGE_VS_FRONTDOOR.md**
- Top cross-link callout pointing at the README decision tree as the entry point.

Swept SPEC.md intro and docs/FRONTDOOR.md for narrative-register leakage ("tesseract", "fourth dimension") — geometry language is now confined to CONCEPT.md. All relative links and anchors verified against existing targets. `npm run lint` exit 0.

https://claude.ai/code/session_01CSkoPDDRCE3bib6NiiTJCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSkoPDDRCE3bib6NiiTJCj)_