### PR TITLE
Config: add configVersion schema field, ambiguity warning, and one precedence story

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -275,7 +275,9 @@ Note: See integration test suite for comprehensive coverage.
 
 ### Schema versioning
 
-Config files do not currently include a `$schema` version field. The implied version is `1`. When a breaking schema change is required, a `"version": 2` field will be added and a migration guide published.
+Bridge configs MAY carry an optional `"configVersion": 1` field. It is the **config-schema** version and is independent of `"version"`, which is the MCP server-version string (e.g. `"1.0.0"`) surfaced to clients. The field is named `configVersion` precisely because `version` was already taken by the server-version string; overloading it would have been ambiguous. When omitted, the implied `configVersion` is `1`. `validate` accepts `configVersion: 1` silently and rejects any other value (`2`, `"1"`, `true`, …) so a config authored against a future, incompatible schema fails loudly. `40mcp init` and `generateFromSpec` emit `configVersion: 1`. When a breaking schema change is required, `configVersion: 2` will be introduced with a migration guide.
+
+The three config surfaces — bridge configs, `.mcp.json` link configs, and `40mcp.settings.json` — what each owns, and the override precedence between them are documented in a single place: [docs/CONFIGURATION_MODEL.md](docs/CONFIGURATION_MODEL.md). A file that carries both `tools` and `mcpServers` is ambiguous: `serve`/`from`/`reverse`/`inspect` read `tools` and `link` reads `mcpServers`; the surfaces are never merged, and `validate` emits a warning naming which one wins.
 
 ### Validation behavior
 

--- a/docs/CONFIGURATION_MODEL.md
+++ b/docs/CONFIGURATION_MODEL.md
@@ -12,6 +12,34 @@ Env vars sit between runtime and CLI, but **only for keys that have an explicit 
 
 ---
 
+## The three config surfaces
+
+There are exactly **three** distinct config surfaces. They are never merged with each other — each is consumed by a different code path. This is the single ownership table; everything below elaborates it.
+
+| Surface | Example file | Shape (key) | Describes | Read by | Owns (authoritative for) |
+|---|---|---|---|---|---|
+| **Bridge config** | `bridge.json`, `github.json` | top-level `tools[]` (+ `baseUrl`, `auth`) | One REST/GraphQL API and the MCP tools it exposes | `serve`, `from-*`/`from`, `reverse`, `inspect`, `validate`, `mix` | Tool/topology shape: baseUrl, auth kind, tool definitions, response transforms, policy annotations |
+| **Link config** | `.mcp.json`, `*.mcp.json` | top-level `mcpServers{}` map | A set of upstream MCP servers to spawn and stitch together | `link` | Upstream identity (entry key = namespace), spawn command/args, transport to each upstream |
+| **Settings** | `40mcp.settings.json` | `bridge`/`frontdoor`/`instance` blocks | How *this running instance* behaves | every command, via `loadAndApplySettings` | Runtime: transport, limits, auth wiring, policy/tenant paths, vault, telemetry, instance metadata |
+
+**What overrides what.** Bridge config and link config are *inputs to a command* — only one of the two applies to any given invocation (you either `serve` a bridge config or `link` a link config). Settings layer onto whichever command you ran, and CLI flags layer on top of settings:
+
+```
+CLI flag  >  env var (where an overlay exists)  >  settings.json  >  config/default
+```
+
+Bridge config and settings own **disjoint** concerns: the bridge config never sets a port or a concurrency limit (that's settings), and settings never define a tool (that's the bridge config). Where a runtime knob *can* be expressed both ways (e.g. transport), settings win over the bridge config's static value, and a CLI flag wins over settings — see *Precedence* below.
+
+### Schema version field (`configVersion`)
+
+Bridge configs may carry an optional `"configVersion": 1`. It is the **config-schema** version, set to `1` today, and is **distinct from `"version"`** — `version` is the MCP server-version string (e.g. `"1.0.0"`) shown to MCP clients. The field is named `configVersion` rather than `version` because the latter was already taken; see [SPEC.md §6](../SPEC.md#6-config-contract). When omitted, the implied version is `1`. `validate` accepts `configVersion: 1` silently and errors on any other value. `40mcp init` and `generateFromSpec` emit it.
+
+### Ambiguous files (`tools` + `mcpServers` together)
+
+A single file that contains **both** a `tools` array and an `mcpServers` map is ambiguous and is never merged. `serve`/`from`/`reverse`/`inspect` read `tools` and ignore `mcpServers`; `link` reads `mcpServers` and ignores `tools`. `validate` emits a warning naming which surface wins. Split such a file into a bridge config and a link config.
+
+---
+
 ## Topology vs runtime
 
 ### Bridge config (topology)

--- a/src/cli.js
+++ b/src/cli.js
@@ -1555,7 +1555,10 @@ async function cmdInit(_flags) {
  }
 
  // ── Build bridge.json ───────────────────────────────────────────────────
+ // `configVersion` is the config-schema version (issue #47), pinned to 1.
+ // It is distinct from `version`, the MCP server-version string.
  const bridgeConfig = {
+ configVersion: 1,
  name: apiName,
  version: '1.0.0',
  };

--- a/src/generate.js
+++ b/src/generate.js
@@ -25,12 +25,15 @@ export const GENERATE_SYSTEM_PROMPT = `You are a 40mcp config generator. You pro
 You MUST output ONLY valid JSON — no markdown, no explanation, no code fences. The JSON must be a complete 40mcp config:
 
 {
+  "configVersion": 1,
   "name": "service-name",
   "version": "1.0.0",
   "baseUrl": "https://api.example.com",
   "auth": { "type": "bearer", "envVar": "SERVICE_API_KEY" },
   "tools": [ ... ]
 }
+
+(\`configVersion\` is the config-schema version — currently always 1 — and is distinct from \`version\`, which is the MCP server-version string shown to clients.)
 
 ## Tool Definition Schema
 
@@ -383,6 +386,10 @@ export function generateFromSpec(spec, options = {}) {
   }
 
   return {
+    // configVersion is the schema version (issue #47), distinct from the
+    // server-version string carried by `version`. Emit it explicitly so
+    // generated configs are pinned to the schema they were written against.
+    configVersion: 1,
     name: toSnakeCase(info.title || 'api-bridge'),
     version: info.version || '1.0.0',
     baseUrl,

--- a/src/validate.js
+++ b/src/validate.js
@@ -27,6 +27,36 @@ export function validateConfig(config) {
     return { valid: false, errors: ['Config must be an object'], warnings: [] };
   }
 
+  // Schema version (issue #47).
+  //
+  // The bare `version` key is ALREADY taken — bridge configs use it as the
+  // MCP server-version string ("1.0.0") passed straight through to
+  // createRestBridge. We therefore introduce `configVersion` as the schema
+  // version field rather than overloading `version`. Only `configVersion: 1`
+  // (the implied/current version) is accepted. Any other value — 2, "1",
+  // true, etc. — is an error so a config authored against a future or
+  // mistyped schema fails loudly instead of being silently mis-parsed.
+  if (config.configVersion !== undefined && config.configVersion !== 1) {
+    errors.push(
+      `config.configVersion "${config.configVersion}" is not supported — only configVersion 1 exists. ` +
+      `Remove the field (it defaults to 1) or pin a 40mcp release that understands this version.`,
+    );
+  }
+
+  // Ambiguity guard (issue #47): a single file carrying BOTH `tools` and
+  // `mcpServers` fuses two separate config surfaces into one. The loaders
+  // never merge them — `serve`/`from`/`reverse`/`inspect` read `config.tools`
+  // and ignore `mcpServers`, while `link` reads `mcpServers` and ignores
+  // `tools`. Warn so the operator knows which half is live for the command
+  // they ran instead of one being silently dropped.
+  if (Array.isArray(config.tools) && config.mcpServers && typeof config.mcpServers === 'object') {
+    warnings.push(
+      'config has both "tools" and "mcpServers" — these are separate config surfaces and are never merged. ' +
+      '`serve`/`from`/`reverse`/`inspect` use "tools" and ignore "mcpServers"; `link` uses "mcpServers" and ignores "tools". ' +
+      'Split them into two files to remove the ambiguity.',
+    );
+  }
+
   // Name
   if (config.name && typeof config.name !== 'string') {
     errors.push('config.name must be a string');

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -220,6 +220,72 @@ describe('validateConfig', () => {
     });
     assert.ok(!result.errors.some((e) => e.includes('required')));
   });
+
+  // ── configVersion schema field (issue #47) ────────────────────────────────
+  it('accepts configVersion: 1 without error or warning', () => {
+    const result = validateConfig({
+      configVersion: 1,
+      baseUrl: 'https://api.example.com',
+      tools: [
+        { name: 'ping', description: 'Ping', method: 'GET', path: '/ping', inputSchema: { type: 'object', properties: {} } },
+      ],
+    });
+    assert.equal(result.valid, true);
+    assert.equal(result.errors.length, 0);
+    assert.ok(!result.warnings.some((w) => w.includes('configVersion')));
+  });
+
+  it('treats omitted configVersion as valid (implied 1)', () => {
+    const result = validateConfig({
+      baseUrl: 'https://api.example.com',
+      tools: [{ name: 'ping', description: 'Ping', method: 'GET', path: '/ping', inputSchema: { type: 'object', properties: {} } }],
+    });
+    assert.equal(result.valid, true);
+    assert.ok(!result.errors.some((e) => e.includes('configVersion')));
+  });
+
+  it('rejects configVersion other than 1', () => {
+    for (const bad of [2, '1', true, 0, 1.5]) {
+      const result = validateConfig({
+        configVersion: bad,
+        baseUrl: 'https://api.example.com',
+        tools: [],
+      });
+      assert.equal(result.valid, false, `configVersion ${JSON.stringify(bad)} should be rejected`);
+      assert.ok(result.errors.some((e) => e.includes('configVersion')));
+    }
+  });
+
+  it('does not overload version (server-version string) as the schema version', () => {
+    // `version: "1.0.0"` is the MCP server-version string and must remain valid.
+    const result = validateConfig({
+      version: '1.0.0',
+      baseUrl: 'https://api.example.com',
+      tools: [{ name: 'ping', description: 'Ping', method: 'GET', path: '/ping', inputSchema: { type: 'object', properties: {} } }],
+    });
+    assert.equal(result.valid, true);
+    assert.ok(!result.errors.some((e) => e.includes('configVersion') || e.includes('version')));
+  });
+
+  // ── tools + mcpServers ambiguity warning (issue #47) ──────────────────────
+  it('warns when a config has both tools and mcpServers', () => {
+    const result = validateConfig({
+      baseUrl: 'https://api.example.com',
+      tools: [{ name: 'ping', description: 'Ping', method: 'GET', path: '/ping', inputSchema: { type: 'object', properties: {} } }],
+      mcpServers: { upstream: { command: '40mcp', args: ['serve', 'x.json'] } },
+    });
+    const ambiguity = result.warnings.find((w) => w.includes('mcpServers') && w.includes('tools'));
+    assert.ok(ambiguity, 'expected an ambiguity warning naming both surfaces');
+    assert.ok(ambiguity.includes('link'), 'warning should state which command uses mcpServers');
+  });
+
+  it('does not warn for a tools-only config', () => {
+    const result = validateConfig({
+      baseUrl: 'https://api.example.com',
+      tools: [{ name: 'ping', description: 'Ping', method: 'GET', path: '/ping', inputSchema: { type: 'object', properties: {} } }],
+    });
+    assert.ok(!result.warnings.some((w) => w.includes('mcpServers')));
+  });
 });
 
 describe('assertValidConfig', () => {


### PR DESCRIPTION
Closes #47.

**Stacked on #48** (steering removal) — merge #48 first; this PR's base is that branch so the diff stays scoped.

Three config surfaces (bridge config, link `.mcp.json`, settings file) had three differently-shaped documents, no schema-version handle, and no single precedence story. SPEC §6 deferred versioning with "the implied version is 1".

## Design decision: `configVersion`, not `version`

Bridge configs already use `version` as the **MCP server-version string** (default `"1.0.0"`, passed to `new Server({ name, version })` and shown to MCP clients — `src/bridge.js`). Overloading it would be ambiguous, so the schema-version field is **`configVersion`**:

- `validateConfig` accepts `configVersion: 1`; any other value (`2`, `"1"`, `true`, `1.5`…) is an error explaining only version 1 is supported; omission = implied 1.
- `generateFromSpec` and the `init` scaffold now emit `configVersion: 1`, so the promised version-2 migration path has something to key on.

## Ambiguity warning

Verified against the actual loaders: `serve`/`from-*`/`reverse`/`inspect` read `config.tools` and ignore `mcpServers`; `link` reads `mcpServers` and ignores `tools` — never merged. `validateConfig` now warns when a file carries both keys, naming which interpretation each command uses.

## One precedence story

docs/CONFIGURATION_MODEL.md now has a single table covering all three surfaces — what each file describes, where it lives, what overrides what (CLI flags > settings > defaults) — linked from SPEC §6 and docs/SETTINGS.md.

## Verification

- Lint clean; unit 1,257 pass / 0 fail (6 new validate cases); integration 221 pass / 0 fail (5 pre-existing network skips)
- All shipped bridge configs in `configs/` still validate (smoke: `40mcp validate configs/github.json` → valid, 22 tools)

https://claude.ai/code/session_01CSkoPDDRCE3bib6NiiTJCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSkoPDDRCE3bib6NiiTJCj)_