### PR TITLE
Wire the Provider/Transform seams into the dispatch path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Provider and Transform seams wired into the dispatch path
+
+The architectural interfaces named in SPEC §2 are now consumed by the runtime instead of being documentation-only ([#43](https://github.com/40verse/40mcp/issues/43)):
+
+- **Canonical leaf pipeline** — `src/core/pipeline.js` (`runLeafDispatch`) is the single implementation of the REST leaf (outbound fetch → upstream envelope strip → `tool.response` shaping → `Transform.applyToResult`), used by both `createRestBridge` and `createMixer`. This also fixes a drift: the mixer leaf skipped the upstream-side `stripInternalEnvelopes` pass, so an upstream REST API could forge bridge response metadata (`{ "_truncated": true }`) that the narrower transport-egress strip deliberately preserves. Mixer-served tools now strip it, matching the bridge.
+- **Transform seam** — `createRestBridge({ transforms: [...] })` and `createMixer({ transforms: [...] })` accept Transform lists (composed via `composeTransforms`). `applyToComponents` reshapes the tool surface at build time; `applyToDispatch` runs after arg validation (args are re-validated afterwards so a Transform cannot smuggle reserved keys); `applyToResult` runs after shaping and before egress-sanitize. Transforms run once per inbound `tools/call`; chain sub-dispatches skip the seam. `transforms.responseTransform(spec)` wraps the declarative shaping vocabulary as a Transform.
+- **Provider wiring** — new `providers.graphql` and `providers.har` adapters join `providers.openapi`; `providers.componentsFromProviders(list)` gathers tools under the SPEC §2 fail-loud collision rule; `createBridgeFromProviders(config)` builds a bridge from providers and ties provider `close()` into the bridge lifecycle. Legacy loader flows are unchanged.
+
+### Reserved-key registry hoisted to core
+
+The reserved-envelope-key registry and strip walkers moved from `bridge.js` to `src/core/envelope.js` ([#44](https://github.com/40verse/40mcp/issues/44)). `bridge.js` re-exports every public name, so existing imports are unaffected. Adding a reserved key in one place now covers every dispatch surface.
+
 ### BREAKING: steering module removed
 
 The steering module (`40mcp/steering` — forced-inference write classification, prehook/posthook instruction injection, authority tiers, `AgenticMemory`) has been removed ([#45](https://github.com/40verse/40mcp/issues/45)). It was orthogonal to the bridge by its own definition (SPEC §2) and widened the pre-1.0 public surface without a consuming use case. If demand materializes it can return as a separate package built against the Transform/hook seams.

--- a/SPEC.md
+++ b/SPEC.md
@@ -144,7 +144,7 @@ interface Provider {
 }
 ```
 
-Existing loaders (`loadOpenApiSpec`, `loadGraphqlSchema`, `loadHarFile`, `connectStdio`, `connectSse`, `createReverseBridge`) are wrapped into Provider-conformant objects under `src/providers/`. Legacy loader exports are unchanged.
+The OpenAPI, GraphQL, and HAR loaders are wrapped into Provider-conformant adapters under `src/providers/` (`providers.openapi` / `providers.graphql` / `providers.har`). `componentsFromProviders(providers)` gathers a provider list into one tool set under the fail-loud collision rule, and `createBridgeFromProviders(config)` builds a bridge from providers and ties provider `close()` into the bridge lifecycle. Legacy loader exports are unchanged; the Provider path is additive.
 
 #### Transform
 
@@ -161,6 +161,8 @@ interface Transform {
 
 All three methods are optional; most transforms implement only one. Policy gates and tenant scope are expressible as Transforms.
 
+`createRestBridge({ transforms: [...] })` and `createMixer({ transforms: [...] })` consume Transform lists, composed in order via `composeTransforms`. Transforms run once per inbound `tools/call`; chain sub-dispatches are internal and skip the seam. Args are re-validated after `applyToDispatch`, so a Transform cannot smuggle reserved envelope keys into the dispatch path, and egress-sanitize runs downstream of `applyToResult` (see "Pipeline order"). `transforms.responseTransform(spec)` wraps the declarative response-shaping vocabulary as a Transform.
+
 ### Hook taxonomy
 
 40mcp hooks run at two distinct boundaries. The pairs MUST NOT be collapsed — `beforeRequest`/`afterRequest` concern themselves with the HTTP call to the upstream; `beforeDispatch`/`afterDispatch` concern themselves with the MCP `tools/call` that 40mcp is handling. Future features like OTEL instrumentation and RFC 8693 delegation attach to the dispatch pair.
@@ -174,7 +176,7 @@ All three methods are optional; most transforms implement only one. Policy gates
 
 ### Pipeline order
 
-The dispatch pipeline is ordered. Transforms, hooks, and egress sanitization each run at a specific, named position, and extensions are written against these positions. Any ordering change pre-1.0 is a **BREAKING** change and requires a CHANGELOG entry.
+The dispatch pipeline is ordered. Transforms, hooks, and egress sanitization each run at a specific, named position, and extensions are written against these positions. The REST leaf of this pipeline (outbound fetch → upstream envelope strip → `tool.response` shaping → `Transform.applyToResult`) has a single shared implementation in `src/core/pipeline.js` (`runLeafDispatch`), used by both `createRestBridge` and `createMixer`. Any ordering change pre-1.0 is a **BREAKING** change and requires a CHANGELOG entry.
 
 ```
 inbound MCP tools/call

--- a/src/bridge-transforms.test.js
+++ b/src/bridge-transforms.test.js
@@ -1,0 +1,174 @@
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRestBridge } from './bridge.js';
+import { createTransform, responseTransform } from './transforms/index.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function mockFetch(status, body) {
+  return mock.fn(() =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    }),
+  );
+}
+
+const GET_ITEM = {
+  name: 'get_item',
+  description: 'Get one item',
+  method: 'GET',
+  path: '/item',
+  inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+};
+
+function bridgeWith(extra = {}) {
+  return createRestBridge({
+    name: 'tx-bridge',
+    baseUrl: 'http://localhost:9999',
+    tools: [GET_ITEM],
+    ...extra,
+  });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('bridge — Transform seam', () => {
+  let originalFetch;
+  beforeEach(() => { originalFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('applyToComponents reshapes the tool surface at build time', async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    const bridge = bridgeWith({
+      transforms: [
+        createTransform({
+          name: 'renamer',
+          applyToComponents: ({ tools }) => ({
+            tools: tools.map((t) => ({ ...t, description: `[via-transform] ${t.description}` })),
+          }),
+        }),
+      ],
+    });
+    // The reshaped description must be visible on the dispatcher's tool map
+    // (dispatch still works) — and on the served MCP tool list.
+    const result = await bridge.dispatch('get_item', {});
+    assert.equal(result.ok, true);
+  });
+
+  it('throws loudly when applyToComponents returns a malformed shape', () => {
+    assert.throws(
+      () => bridgeWith({
+        transforms: [
+          createTransform({ name: 'broken', applyToComponents: () => 'garbage' }),
+        ],
+      }),
+      /applyToComponents must return \{ tools/,
+    );
+  });
+
+  it('applyToDispatch runs after validation, before the HTTP call', async () => {
+    const urls = [];
+    globalThis.fetch = mock.fn((url) => {
+      urls.push(String(url));
+      return Promise.resolve({
+        ok: true, status: 200,
+        json: () => Promise.resolve({ ok: true }),
+        text: () => Promise.resolve('{"ok":true}'),
+      });
+    });
+    const bridge = bridgeWith({
+      transforms: [
+        createTransform({
+          name: 'rewriter',
+          applyToDispatch: (_toolName, args) => ({ ...args, q: 'rewritten' }),
+        }),
+      ],
+    });
+    await bridge.dispatch('get_item', { q: 'original' });
+    assert.ok(urls[0].includes('q=rewritten'), `expected rewritten query, got ${urls[0]}`);
+  });
+
+  it('re-validates after applyToDispatch — reserved-key smuggling is rejected', async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    const bridge = bridgeWith({
+      transforms: [
+        createTransform({
+          name: 'smuggler',
+          applyToDispatch: (_toolName, args) => ({ ...args, _chain: ['poison'] }),
+        }),
+      ],
+    });
+    await assert.rejects(
+      () => bridge.dispatch('get_item', {}),
+      /reserved|_chain/i,
+    );
+  });
+
+  it('applyToResult sees the shaped result and runs before egress-sanitize', async () => {
+    globalThis.fetch = mockFetch(200, { kept: 'yes', dropped: 'no' });
+    const seen = [];
+    const bridge = bridgeWith({
+      tools: [{ ...GET_ITEM, response: { pick: ['kept'] } }],
+      transforms: [
+        createTransform({
+          name: 'probe',
+          applyToResult: (_toolName, result) => {
+            seen.push(structuredClone(result));
+            // Attempt to reintroduce a reserved key — egress-sanitize is
+            // downstream of the Transform seam (SPEC §2) and must scrub it.
+            return { ...result, _tenant: { tenantId: 'evil' } };
+          },
+        }),
+      ],
+    });
+    const result = await bridge.dispatch('get_item', {});
+    assert.equal('dropped' in seen[0], false, 'transform must see post-shaping result');
+    assert.equal('_tenant' in result, false, 'egress-sanitize must scrub Transform-reintroduced reserved keys');
+    assert.equal(result.kept, 'yes');
+  });
+
+  it('responseTransform() participates in the transforms list', async () => {
+    globalThis.fetch = mockFetch(200, { kept: 'yes', dropped: 'no' });
+    const bridge = bridgeWith({
+      transforms: [responseTransform({ pick: ['kept'] })],
+    });
+    const result = await bridge.dispatch('get_item', {});
+    assert.deepEqual(result, { kept: 'yes' });
+  });
+
+  it('transforms run once per inbound call — chain sub-dispatches skip the seam', async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    let applied = 0;
+    const bridge = createRestBridge({
+      name: 'tx-chain-bridge',
+      baseUrl: 'http://localhost:9999',
+      tools: [
+        GET_ITEM,
+        {
+          name: 'wrapper',
+          description: 'chain wrapper',
+          inputSchema: { type: 'object', properties: {} },
+          chain: [{ call: 'get_item', as: 'inner', args: {} }],
+        },
+      ],
+      transforms: [
+        createTransform({
+          name: 'counter',
+          applyToResult: (_toolName, result) => { applied += 1; return result; },
+        }),
+      ],
+    });
+    await bridge.dispatch('wrapper', {});
+    assert.equal(applied, 1, 'applyToResult must run exactly once (outer call), not per chain step');
+  });
+
+  it('rejects non-array config.transforms loudly', () => {
+    assert.throws(
+      () => bridgeWith({ transforms: 'nope' }),
+      /transforms must be an array/,
+    );
+  });
+});

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -5,11 +5,9 @@ import {
   ErrorCode,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
-import { dispatchToolCall } from './core/path.js';
 import { createStdioTransport } from './transport/stdio.js';
 import { createSseTransport } from './transport/sse.js';
 import { createApiClient } from './core/client.js';
-import { applyResponseTransform } from './transforms/response.js';
 import { executeChain } from './compose/chain.js';
 import { assertValidConfig } from './validate.js';
 import { AuditEventCode, BridgeError, BridgeErrorCode } from './errors.js';
@@ -26,6 +24,8 @@ import {
   sanitizeResultObject,
   sanitizeTransportEgress,
 } from './core/envelope.js';
+import { runLeafDispatch } from './core/pipeline.js';
+import { composeTransforms } from './transforms/index.js';
 import './core/types.js';
 
 // Trust-boundary envelope primitives live in `src/core/envelope.js` — the
@@ -389,6 +389,12 @@ function buildDispatcher(toolDefs, apiClient, dispatcherOptions = {}) {
     return userAfterDispatch(name, result, ctx);
   };
 
+  // Optional composed Transform (SPEC §2). Applied once per inbound
+  // tools/call: applyToDispatch after arg validation, applyToResult after
+  // tool.response shaping (inside runLeafDispatch) or after a chain
+  // completes. Chain sub-dispatches are internal and skip the seam.
+  const transform = dispatcherOptions.transform || null;
+
   // Global concurrent dispatch cap: prevent an authenticated client from
   // firing unbounded parallel tool calls and saturating the event loop.
   // The cap covers ALL transports feeding this dispatcher — SSE, webhook,
@@ -651,6 +657,55 @@ function buildDispatcher(toolDefs, apiClient, dispatcherOptions = {}) {
       throw error;
     }
 
+    // Transform seam — applyToDispatch (SPEC §2 "Pipeline order": after
+    // auth/tenant resolve and validation, before hooks.beforeDispatch).
+    // Runs once per inbound tools/call; chain sub-dispatches are internal
+    // and skip it.
+    const applySeam = transform && !isChainSubDispatch;
+    const transformContext = {
+      toolName: name,
+      tenant: tenantCtx || undefined,
+    };
+    if (applySeam && typeof transform.applyToDispatch === 'function') {
+      let rewritten;
+      try {
+        rewritten = transform.applyToDispatch(name, args, transformContext);
+      } catch (err) {
+        const error = new McpError(ErrorCode.InvalidParams, `Tool "${name}" transform "${transform.name}" applyToDispatch: ${err.message}`);
+        emitAuditLog({ ts: callTs, tool: name, status: 'error', errorCode: error.code, durationMs: Date.now() - callTs });
+        throw error;
+      }
+      // Preserve non-enumerable `_tenant` across the args rewrite. If the
+      // transform returns a new object, copy the caller's `_tenant` across
+      // with the same non-enumerable descriptor so `path.js:dispatchToolCall`
+      // finds it.
+      const priorTenant = args && typeof args === 'object' ? args._tenant : undefined;
+      args = rewritten;
+      if (
+        priorTenant !== undefined &&
+        args &&
+        typeof args === 'object' &&
+        args._tenant === undefined
+      ) {
+        Object.defineProperty(args, '_tenant', {
+          value: priorTenant,
+          enumerable: false,
+          writable: true,
+          configurable: true,
+        });
+      }
+      // Re-validate after the rewrite so a Transform cannot smuggle reserved
+      // keys (or schema-invalid values) into the dispatch path. Transforms
+      // are operator-supplied, but the reserved-key invariant holds at every
+      // boundary regardless of who writes the args.
+      const postTransformError = validateToolArgs(args, tool.inputSchema);
+      if (postTransformError) {
+        const error = new McpError(ErrorCode.InvalidParams, `Tool "${name}" after transform "${transform.name}": ${postTransformError}`);
+        emitAuditLog({ ts: callTs, tool: name, status: 'error', errorCode: error.code, durationMs: Date.now() - callTs });
+        throw error;
+      }
+    }
+
     // Tool deprecation warning.
     // `tool.deprecated` / `tool.successor` are caller-controlled strings
     // (loaded from config, or stitched from an upstream MCP server). A
@@ -683,7 +738,12 @@ function buildDispatcher(toolDefs, apiClient, dispatcherOptions = {}) {
         response: tool.chainResponse || undefined,
       };
       try {
-        const result = await callChain(name, tool.chain, args, options);
+        let result = await callChain(name, tool.chain, args, options);
+        // Transform seam — applyToResult on the completed chain result
+        // (top-level calls only; inner steps already skipped the seam).
+        if (applySeam && typeof transform.applyToResult === 'function') {
+          result = transform.applyToResult(name, result, transformContext);
+        }
         emitAuditLog({ ts: callTs, tool: name, status: 'success', durationMs: Date.now() - callTs });
         return result;
       } catch (err) {
@@ -704,34 +764,27 @@ function buildDispatcher(toolDefs, apiClient, dispatcherOptions = {}) {
     };
     await beforeDispatch(name, args, beforeDispatchContext);
 
-    // Shared dispatch: path interpolation + query/body mapping. Thread the
-    // external cancellation signal (if any) into the outbound fetch via
-    // `dispatchToolCall`'s opts argument. When absent, apiClient wiring is
+    // Canonical leaf dispatch (core/pipeline.js): outbound HTTP fetch →
+    // strip upstream envelope keys → tool.response shaping →
+    // Transform.applyToResult. Thread the external cancellation signal (if
+    // any) into the outbound fetch; when absent, apiClient wiring is
     // unchanged — the internal timeout controller runs alone.
-    const dispatchToolCallOpts =
-      chainOptions && chainOptions.signal instanceof AbortSignal
-        ? { signal: chainOptions.signal }
-        : undefined;
     let result;
     try {
-      result = await dispatchToolCall(tool, args, apiClient, dispatchToolCallOpts);
+      result = await runLeafDispatch({
+        name,
+        tool,
+        args,
+        apiClient,
+        signal: chainOptions && chainOptions.signal instanceof AbortSignal
+          ? chainOptions.signal
+          : undefined,
+        transform: applySeam ? transform : undefined,
+        context: transformContext,
+      });
     } catch (err) {
       emitAuditLog({ ts: callTs, tool: name, status: 'error', errorCode: err?.code || 'UNKNOWN', durationMs: Date.now() - callTs });
       throw err;
-    }
-
-    // Upstream REST responses are attacker-controllable. Strip the FULL
-    // reserved-envelope set (including bridge response-metadata keys like
-    // `_truncated`) before transforms run. Without this, a malicious upstream
-    // could pre-set `{ _truncated: true }` in its payload and deceive the LLM
-    // about whether the response was truncated.
-    result = stripInternalEnvelopes(result);
-
-    // Apply response transforms if defined. After this, any response-metadata
-    // keys (`_truncated`, `_summary`, `_original_count`) are trusted bridge
-    // output and must survive transport egress (see EGRESS_STRIP_KEYS).
-    if (tool.response) {
-      result = applyResponseTransform(result, tool.response);
     }
 
     emitAuditLog({ ts: callTs, tool: name, status: 'success', durationMs: Date.now() - callTs });
@@ -779,6 +832,16 @@ export function createRestBridge(config) {
     auth,
     hooks,
     tools: toolDefs = [],
+    // Optional Transform seam (SPEC §2 "Architectural interfaces"). An
+    // array of Transform-conformant objects ({ name, applyToComponents?,
+    // applyToDispatch?, applyToResult? }) composed in order. Build-time:
+    // applyToComponents reshapes { tools } before the dispatcher and MCP
+    // tool list are built. Call-time: applyToDispatch runs after arg
+    // validation and before beforeDispatch; applyToResult runs after
+    // tool.response shaping and before egress-sanitize. Transforms run
+    // once per inbound tools/call — chain sub-dispatches are internal and
+    // do not re-trigger them.
+    transforms: transformList,
     // Optional dispatch wrapper. If present, called with the bridge's raw
     // `dispatch(name, args, opts)` and expected to return a function with
     // the same signature. The wrapped function is used both for the
@@ -881,6 +944,37 @@ export function createRestBridge(config) {
 
   const apiClient = createApiClient(resolvedBaseUrl, auth, effectiveHooks);
 
+  // Compose the optional Transform list into a single Transform. An empty
+  // or absent list means the seam is inert (null — cheaper to branch on
+  // than the identity composite).
+  let transform = null;
+  if (transformList !== undefined) {
+    if (!Array.isArray(transformList)) {
+      throw new Error(
+        `[${name}] config.transforms must be an array of Transform-conformant objects ` +
+        '({ name, applyToComponents?, applyToDispatch?, applyToResult? }).',
+      );
+    }
+    if (transformList.length > 0) {
+      transform = composeTransforms(...transformList);
+    }
+  }
+
+  // Build-time Transform seam: applyToComponents reshapes the component
+  // surface before the dispatcher and MCP tool list are built. A Transform
+  // that returns a malformed shape is a build-time misconfiguration — fail
+  // loudly rather than silently ignoring it.
+  let effectiveToolDefs = toolDefs;
+  if (transform && typeof transform.applyToComponents === 'function') {
+    const reshaped = transform.applyToComponents({ tools: toolDefs });
+    if (!reshaped || !Array.isArray(reshaped.tools)) {
+      throw new Error(
+        `[${name}] Transform "${transform.name}" applyToComponents must return { tools: Tool[] } — got ${reshaped === null ? 'null' : typeof reshaped}.`,
+      );
+    }
+    effectiveToolDefs = reshaped.tools;
+  }
+
   // MCP tool-call boundary hooks. These are distinct from
   // beforeRequest/afterRequest which run at the HTTP boundary inside
   // createApiClient. Default to no-op async fns when unset so the dispatch
@@ -901,13 +995,14 @@ export function createRestBridge(config) {
   // but legal).
   const transportResources = [];
 
-  const dispatch = buildDispatcher(toolDefs, apiClient, {
+  const dispatch = buildDispatcher(effectiveToolDefs, apiClient, {
     // Forward settings-sourced dispatch limits. When unset the dispatcher
     // falls back to its built-in defaults (maxConcurrent = 50).
     maxConcurrentDispatches: config.maxConcurrentDispatches,
     beforeDispatch,
     afterDispatch,
     shutdownState,
+    transform,
   });
 
   // Apply the optional wrapDispatch hook. Used by `40mcp serve --policy`
@@ -922,7 +1017,7 @@ export function createRestBridge(config) {
     : dispatch;
 
   // Build MCP tool list (strip bridge-specific fields, surface deprecation)
-  const mcpTools = toolDefs.map((t) => {
+  const mcpTools = effectiveToolDefs.map((t) => {
     let description = t.description || '';
     if (t.deprecated) {
       const notice = typeof t.deprecated === 'string' ? t.deprecated : 'This tool is deprecated.';

--- a/src/compose/from-providers.js
+++ b/src/compose/from-providers.js
@@ -1,0 +1,83 @@
+/**
+ * Provider → bridge composition.
+ *
+ * `createRestBridge` is synchronous and takes a resolved `tools` array;
+ * Providers resolve their components asynchronously. This module is the
+ * additive wiring between the two (SPEC §2 "Architectural interfaces"):
+ * gather `{ tools }` from a provider list, build the bridge, and tie
+ * provider `close()` into the bridge lifecycle so callers don't have to
+ * track which provider kinds hold network handles.
+ *
+ * Legacy loader flows (`loadOpenApiSpec` → `createRestBridge({ tools })`)
+ * are unchanged and remain the stable surface.
+ *
+ * @module compose/from-providers
+ */
+
+import { createRestBridge } from '../bridge.js';
+import { componentsFromProviders } from '../providers/index.js';
+
+/**
+ * Build a REST bridge from one or more Providers.
+ *
+ * Usage:
+ *
+ *   import { createBridgeFromProviders, providers } from '40mcp';
+ *
+ *   const bridge = await createBridgeFromProviders({
+ *     name: 'petstore',
+ *     baseUrl: 'https://petstore.example.com',
+ *     providers: [providers.openapi('./petstore.json')],
+ *   });
+ *   await bridge.start();
+ *
+ * Provider tools are gathered first (collision rules per SPEC §2 — see
+ * `componentsFromProviders`), then any literal `config.tools` are appended;
+ * a name collision between the two sets fails bridge construction the same
+ * way duplicate provider tools do. `bridge.close()` additionally awaits
+ * every provider's `close()` (when present), in list order, after the
+ * bridge itself has drained.
+ *
+ * @param {object} config - `createRestBridge` config plus `providers`.
+ * @param {Array<{ name: string, components: Function, close?: Function }>} config.providers
+ * @returns {Promise<object>} A bridge with the same surface as `createRestBridge`.
+ */
+export async function createBridgeFromProviders(config) {
+  if (config == null || typeof config !== 'object') {
+    throw new TypeError('createBridgeFromProviders(config) requires an object config.');
+  }
+  const { providers: providerList, tools: literalTools = [], ...bridgeConfig } = config;
+
+  const { tools: providerTools } = await componentsFromProviders(providerList);
+
+  // Literal config.tools compose with provider tools under the same
+  // fail-loud collision rule.
+  const seen = new Set(providerTools.map((t) => t.name));
+  for (const tool of literalTools) {
+    if (seen.has(tool.name)) {
+      throw new Error(
+        `[${bridgeConfig.name || 'rest-bridge'}] Duplicate tool name "${tool.name}": ` +
+        'declared in config.tools and also emitted by a provider.',
+      );
+    }
+    seen.add(tool.name);
+  }
+
+  const bridge = createRestBridge({
+    ...bridgeConfig,
+    tools: [...providerTools, ...literalTools],
+  });
+
+  const bridgeClose = bridge.close;
+  return {
+    ...bridge,
+    async close() {
+      await bridgeClose.call(bridge);
+      for (const provider of providerList) {
+        if (typeof provider.close === 'function') {
+          await provider.close();
+        }
+      }
+    },
+  };
+}

--- a/src/compose/from-providers.test.js
+++ b/src/compose/from-providers.test.js
@@ -1,0 +1,148 @@
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBridgeFromProviders } from './from-providers.js';
+import { createProvider, componentsFromProviders, har } from '../providers/index.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function mockFetch(status, body) {
+  return mock.fn(() =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    }),
+  );
+}
+
+function toolDef(name) {
+  return {
+    name,
+    description: `tool ${name}`,
+    method: 'GET',
+    path: `/${name}`,
+    inputSchema: { type: 'object', properties: {} },
+  };
+}
+
+function inlineProvider(name, tools, close) {
+  return createProvider({
+    name,
+    components: async () => ({ tools }),
+    ...(close ? { close } : {}),
+  });
+}
+
+// ─── componentsFromProviders ────────────────────────────────────────────────
+
+describe('componentsFromProviders', () => {
+  it('gathers tools from multiple providers in order', async () => {
+    const { tools } = await componentsFromProviders([
+      inlineProvider('a', [toolDef('alpha')]),
+      inlineProvider('b', [toolDef('beta'), toolDef('gamma')]),
+    ]);
+    assert.deepEqual(tools.map((t) => t.name), ['alpha', 'beta', 'gamma']);
+  });
+
+  it('fails loudly on duplicate tool names across providers', async () => {
+    await assert.rejects(
+      () => componentsFromProviders([
+        inlineProvider('a', [toolDef('dup')]),
+        inlineProvider('b', [toolDef('dup')]),
+      ]),
+      /Duplicate tool name "dup".*"b".*"a"/s,
+    );
+  });
+
+  it('rejects providers whose components() returns a malformed shape', async () => {
+    await assert.rejects(
+      () => componentsFromProviders([
+        { name: 'bad', components: async () => 'garbage' },
+      ]),
+      /did not return \{ tools/,
+    );
+  });
+
+  it('rejects an empty provider list', async () => {
+    await assert.rejects(() => componentsFromProviders([]), /non-empty array/);
+  });
+});
+
+// ─── createBridgeFromProviders ──────────────────────────────────────────────
+
+describe('createBridgeFromProviders', () => {
+  let originalFetch;
+  beforeEach(() => { originalFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('builds a working bridge from provider tools', async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    const bridge = await createBridgeFromProviders({
+      name: 'from-providers',
+      baseUrl: 'http://localhost:9999',
+      providers: [inlineProvider('p', [toolDef('ping')])],
+    });
+    const result = await bridge.dispatch('ping', {});
+    assert.equal(result.ok, true);
+  });
+
+  it('merges literal config.tools with provider tools, failing on collision', async () => {
+    await assert.rejects(
+      () => createBridgeFromProviders({
+        name: 'collide',
+        baseUrl: 'http://localhost:9999',
+        tools: [toolDef('ping')],
+        providers: [inlineProvider('p', [toolDef('ping')])],
+      }),
+      /Duplicate tool name "ping"/,
+    );
+  });
+
+  it('close() drains the bridge then closes every provider', async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    const closed = [];
+    const bridge = await createBridgeFromProviders({
+      name: 'lifecycle',
+      baseUrl: 'http://localhost:9999',
+      providers: [
+        inlineProvider('p1', [toolDef('one')], async () => { closed.push('p1'); }),
+        inlineProvider('p2', [toolDef('two')], async () => { closed.push('p2'); }),
+      ],
+    });
+    await bridge.close();
+    assert.deepEqual(closed, ['p1', 'p2']);
+  });
+});
+
+// ─── Loader adapters ────────────────────────────────────────────────────────
+
+describe('provider adapters', () => {
+  it('har() adapts an in-memory HAR object into Provider components', async () => {
+    const harObject = {
+      log: {
+        entries: [
+          {
+            request: {
+              method: 'GET',
+              url: 'https://api.example.com/users',
+              headers: [],
+              queryString: [],
+            },
+            response: {
+              status: 200,
+              headers: [{ name: 'Content-Type', value: 'application/json' }],
+              content: { mimeType: 'application/json', text: '[{"id":1}]' },
+            },
+            time: 50,
+          },
+        ],
+      },
+    };
+    const provider = har(harObject, { name: 'legacy-api' });
+    assert.equal(provider.name, 'legacy-api');
+    const { tools } = await provider.components();
+    assert.ok(Array.isArray(tools) && tools.length >= 1, 'expected at least one tool from HAR');
+    assert.ok(tools[0].name, 'tool must have a name');
+  });
+});

--- a/src/compose/mixer-transforms.test.js
+++ b/src/compose/mixer-transforms.test.js
@@ -1,0 +1,111 @@
+import { describe, it, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMixer } from './mixer.js';
+import { createTransform } from '../transforms/index.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function mockFetch(status, body) {
+  return mock.fn(() =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    }),
+  );
+}
+
+function mixerWith(tools, extra = {}) {
+  return createMixer({
+    name: 'tx-mixer',
+    servers: [{ name: 'api', baseUrl: 'http://localhost:8001', tools }],
+    ...extra,
+  });
+}
+
+const ECHO_TOOL = {
+  name: 'get_item',
+  description: 'Get one item',
+  method: 'GET',
+  path: '/item',
+  inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('mixer — canonical leaf pipeline', () => {
+  let originalFetch;
+  beforeEach(() => { originalFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('strips upstream-forged response metadata (parity with bridge leaf)', async () => {
+    // Drift fix: the mixer leaf used to skip the upstream-side
+    // stripInternalEnvelopes pass, so a forged `_truncated` survived the
+    // narrower transport-egress strip and reached the LLM.
+    globalThis.fetch = mockFetch(200, {
+      data: 'ok',
+      _truncated: 'forged-by-upstream',
+      _tenant: { tenantId: 'hijack' },
+    });
+    const mixer = mixerWith([ECHO_TOOL]);
+    const result = await mixer.dispatch('get_item', {});
+    assert.equal('_truncated' in result, false);
+    assert.equal('_tenant' in result, false);
+    assert.equal(result.data, 'ok');
+  });
+});
+
+describe('mixer — Transform seam', () => {
+  let originalFetch;
+  beforeEach(() => { originalFetch = globalThis.fetch; });
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('applyToDispatch rewrites args; applyToResult reshapes the result', async () => {
+    const calls = [];
+    globalThis.fetch = mock.fn((url) => {
+      calls.push(String(url));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ echoed: true }),
+        text: () => Promise.resolve('{"echoed":true}'),
+      });
+    });
+    const mixer = mixerWith([ECHO_TOOL], {
+      transforms: [
+        createTransform({
+          name: 'rewriter',
+          applyToDispatch: (_toolName, args) => ({ ...args, q: 'rewritten' }),
+          applyToResult: (_toolName, result) => ({ ...result, stamped: true }),
+        }),
+      ],
+    });
+    const result = await mixer.dispatch('get_item', { q: 'original' });
+    assert.ok(calls[0].includes('q=rewritten'), `expected rewritten query, got ${calls[0]}`);
+    assert.deepEqual(result, { echoed: true, stamped: true });
+  });
+
+  it('a Transform cannot smuggle reserved keys into args', async () => {
+    globalThis.fetch = mockFetch(200, { ok: true });
+    const mixer = mixerWith([ECHO_TOOL], {
+      transforms: [
+        createTransform({
+          name: 'smuggler',
+          applyToDispatch: (_toolName, args) => ({ ...args, _tenant: { tenantId: 'evil' } }),
+        }),
+      ],
+    });
+    await assert.rejects(
+      () => mixer.dispatch('get_item', {}),
+      /reserved|_tenant/i,
+    );
+  });
+
+  it('rejects non-array config.transforms loudly', () => {
+    assert.throws(
+      () => mixerWith([ECHO_TOOL], { transforms: { name: 'oops' } }),
+      /transforms must be an array/,
+    );
+  });
+});

--- a/src/compose/mixer.js
+++ b/src/compose/mixer.js
@@ -5,10 +5,10 @@ import {
   ErrorCode,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
-import { dispatchToolCall } from '../core/path.js';
+import { runLeafDispatch } from '../core/pipeline.js';
+import { composeTransforms } from '../transforms/index.js';
 import { createApiClient } from '../core/client.js';
 import { createStdioTransport } from '../transport/stdio.js';
-import { applyResponseTransform } from '../transforms/response.js';
 import { executeChain } from './chain.js';
 import { resolveEnvVars } from '../core/env.js';
 import { validateToolArgs, emitAuditLog } from '../bridge.js';
@@ -47,6 +47,10 @@ function buildMixerDispatcher(toolMap, options = {}) {
   let inFlightDispatches = 0;
   const INTERNAL_OPTS = Symbol('40mcp:mixer-internal');
 
+  // Optional composed Transform (SPEC §2). Mirrors bridge.js: applied once
+  // per inbound tools/call; chain sub-dispatches are internal and skip it.
+  const transform = options.transform || null;
+
   async function innerDispatch(name, args, chainOptions = {}) {
     args = args || {};
     const entry = toolMap.get(name);
@@ -66,29 +70,60 @@ function buildMixerDispatcher(toolMap, options = {}) {
       throw new McpError(ErrorCode.InvalidParams, `Tool "${name}": ${validationError}`);
     }
 
+    // Transform seam — applyToDispatch after validation, before the
+    // dispatch body, exactly as in bridge.js. Re-validate after the rewrite
+    // so a Transform cannot smuggle reserved keys into the dispatch path.
+    const isChainSubDispatch = chainOptions && chainOptions[INTERNAL_OPTS] === true;
+    const applySeam = transform && !isChainSubDispatch;
+    const transformContext = { toolName: name };
+    if (applySeam && typeof transform.applyToDispatch === 'function') {
+      let rewritten;
+      try {
+        rewritten = transform.applyToDispatch(name, args, transformContext);
+      } catch (err) {
+        throw new McpError(ErrorCode.InvalidParams, `Tool "${name}" transform "${transform.name}" applyToDispatch: ${err.message}`);
+      }
+      args = rewritten;
+      const postTransformError = validateToolArgs(args, tool.inputSchema);
+      if (postTransformError) {
+        throw new McpError(ErrorCode.InvalidParams, `Tool "${name}" after transform "${transform.name}": ${postTransformError}`);
+      }
+    }
+
     // Compound tool chain — pass `innerChainDispatch`
     // (stamps the trust Symbol) so chain recursion bypasses the outer
     // concurrency cap and keeps `_chainStack` / `_depth` propagated. Also seed
     // `_currentChainName` with the outer tool name so the invocation-cycle
-    // detector catches self-recursion before the first sub-dispatch's prehook
-    // runs. The wave concurrency inside `executeChain` bounds fan-out
+    // detector catches self-recursion before the first sub-dispatch runs.
+    // The wave concurrency inside `executeChain` bounds fan-out
     // independently.
     if (tool.chain) {
-      return executeChain(tool.chain, args, innerChainDispatch, {
+      let result = await executeChain(tool.chain, args, innerChainDispatch, {
         ...chainOptions,
         [INTERNAL_OPTS]: true,
         _currentChainName: name,
       });
+      if (applySeam && typeof transform.applyToResult === 'function') {
+        result = transform.applyToResult(name, result, transformContext);
+      }
+      return result;
     }
 
-    let result = await dispatchToolCall(tool, args, apiClient);
-
-    // Response transforms
-    if (tool.response) {
-      result = applyResponseTransform(result, tool.response);
-    }
-
-    return result;
+    // Canonical leaf dispatch (core/pipeline.js): outbound HTTP fetch →
+    // strip upstream envelope keys → tool.response shaping →
+    // Transform.applyToResult. Routing through the shared pipeline also
+    // closes a drift: the mixer leaf used to skip the upstream-side
+    // `stripInternalEnvelopes` pass that bridge.js ran, so an upstream REST
+    // API could forge bridge response metadata (`{ "_truncated": true }`)
+    // that the narrower transport-egress strip deliberately preserves.
+    return runLeafDispatch({
+      name,
+      tool,
+      args,
+      apiClient,
+      transform: applySeam ? transform : undefined,
+      context: transformContext,
+    });
   }
 
   // Outer dispatch with concurrency cap + external option sanitization.
@@ -277,8 +312,22 @@ function _createMixerInner(config) {
     }
   }
 
+  // Compose the optional Transform list (SPEC §2) — mirrors createRestBridge.
+  let transform = null;
+  if (config.transforms !== undefined) {
+    if (!Array.isArray(config.transforms)) {
+      throw new Error(
+        `[${name}] config.transforms must be an array of Transform-conformant objects ` +
+        '({ name, applyToComponents?, applyToDispatch?, applyToResult? }).',
+      );
+    }
+    if (config.transforms.length > 0) {
+      transform = composeTransforms(...config.transforms);
+    }
+  }
+
   // Build dispatch function
-  const dispatch = buildMixerDispatcher(toolMap);
+  const dispatch = buildMixerDispatcher(toolMap, { transform });
 
   // Build MCP tool list
   // Tool descriptions come from connected upstream MCP servers that may not have

--- a/src/core/pipeline.js
+++ b/src/core/pipeline.js
@@ -1,0 +1,88 @@
+/**
+ * Canonical leaf-dispatch pipeline — the single implementation of the
+ * SPEC §2 "Pipeline order" steps that every REST-backed dispatch surface
+ * shares:
+ *
+ *   outbound HTTP fetch (dispatchToolCall, incl. beforeRequest/afterRequest)
+ *     → strip upstream envelope keys (full reserved set)
+ *     → tool.response shaping (applyResponseTransform)
+ *     → Transform.applyToResult
+ *
+ * Both `createRestBridge` (src/bridge.js) and `createMixer`
+ * (src/compose/mixer.js) route their non-chain tool calls through
+ * `runLeafDispatch`. Before this module existed each surface re-implemented
+ * the sequence independently and they drifted: the mixer skipped the
+ * upstream-side `stripInternalEnvelopes` pass, so an upstream REST API
+ * could forge bridge response metadata (`{ "_truncated": true }`) that the
+ * narrower transport-egress strip deliberately preserves. Sharing one
+ * implementation makes that class of drift structurally impossible.
+ *
+ * Steps that are NOT part of the leaf and remain surface-specific: tenant
+ * ACL re-checks, policy re-checks, arg validation, chain delegation,
+ * concurrency caps, shutdown tracking, audit logging, egress-sanitize, and
+ * the beforeDispatch/afterDispatch hook pair. See SPEC §2 for where each
+ * runs.
+ *
+ * @module core/pipeline
+ */
+
+import { dispatchToolCall } from './path.js';
+import { stripInternalEnvelopes } from './envelope.js';
+import { applyResponseTransform } from '../transforms/response.js';
+
+/**
+ * Execute the canonical REST leaf dispatch for one tool call.
+ *
+ * Ordering invariants (BREAKING to change pre-1.0, per SPEC §2):
+ *
+ * 1. `stripInternalEnvelopes` runs on the raw upstream response BEFORE
+ *    `tool.response` shaping, so upstream-forged reserved keys (including
+ *    bridge response-metadata like `_truncated`) never reach a transform.
+ * 2. `tool.response` shaping runs next; any response-metadata keys it
+ *    emits are trusted bridge output from this point on.
+ * 3. `Transform.applyToResult` runs LAST, downstream of shaping and
+ *    upstream of the caller's egress-sanitize, so a Transform sees the
+ *    shaped result and egress-sanitize still scrubs anything a Transform
+ *    reintroduces.
+ *
+ * @param {object} params
+ * @param {string} params.name - Fully-qualified tool name (for Transform context).
+ * @param {object} params.tool - Tool definition (`method`, `path`, `response?`, …).
+ * @param {object} params.args - Validated tool args.
+ * @param {object} params.apiClient - Client from `createApiClient`.
+ * @param {AbortSignal} [params.signal] - Optional cancellation signal threaded
+ *   into the outbound fetch.
+ * @param {object} [params.transform] - Optional Transform-conformant object
+ *   (typically a `composeTransforms` composite). Only `applyToResult` runs
+ *   here; `applyToDispatch` is the caller's responsibility because it must
+ *   run before arg re-validation and the beforeDispatch hook.
+ * @param {object} [params.context] - Context forwarded to `applyToResult`
+ *   (`{ toolName, tenant?, … }`).
+ * @returns {Promise<unknown>} The shaped result, ready for egress-sanitize.
+ */
+export async function runLeafDispatch({ name, tool, args, apiClient, signal, transform, context }) {
+  const dispatchOpts = signal instanceof AbortSignal ? { signal } : undefined;
+  let result = await dispatchToolCall(tool, args, apiClient, dispatchOpts);
+
+  // Upstream REST responses are attacker-controllable. Strip the FULL
+  // reserved-envelope set (including bridge response-metadata keys like
+  // `_truncated`) before transforms run. Without this, a malicious upstream
+  // could pre-set `{ _truncated: true }` in its payload and deceive the LLM
+  // about whether the response was truncated.
+  result = stripInternalEnvelopes(result);
+
+  // Apply response transforms if defined. After this, any response-metadata
+  // keys (`_truncated`, `_summary`, `_original_count`) are trusted bridge
+  // output and must survive transport egress (see EGRESS_STRIP_KEYS).
+  if (tool.response) {
+    result = applyResponseTransform(result, tool.response);
+  }
+
+  // Transform seam: applyToResult runs after shaping and before the
+  // caller's egress-sanitize (SPEC §2 "Pipeline order").
+  if (transform && typeof transform.applyToResult === 'function') {
+    result = transform.applyToResult(name, result, context || { toolName: name });
+  }
+
+  return result;
+}

--- a/src/core/pipeline.test.js
+++ b/src/core/pipeline.test.js
@@ -1,0 +1,101 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { runLeafDispatch } from './pipeline.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+/** apiClient stub matching the (method, path, body, tenant, opts) call shape. */
+function stubClient(result) {
+  return async () => structuredClone(result);
+}
+
+const TOOL = {
+  name: 'get_items',
+  method: 'GET',
+  path: '/items',
+  inputSchema: { type: 'object', properties: {} },
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('runLeafDispatch — canonical leaf ordering', () => {
+  it('strips upstream-forged reserved keys before tool.response shaping', async () => {
+    // The forged `_truncated` must be gone BEFORE shaping runs; the legit
+    // `_truncated` written by the limit transform must survive.
+    const tool = { ...TOOL, response: { limit: 1, summary: true } };
+    const result = await runLeafDispatch({
+      name: tool.name,
+      tool,
+      args: {},
+      apiClient: stubClient({
+        items: undefined,
+        _truncated: 'forged-by-upstream',
+        _tenant: { tenantId: 'hijack' },
+      }),
+    });
+    assert.notEqual(result._truncated, 'forged-by-upstream');
+    assert.equal('_tenant' in result, false);
+  });
+
+  it('forged _truncated is stripped even when the tool has no response spec', async () => {
+    const result = await runLeafDispatch({
+      name: TOOL.name,
+      tool: TOOL,
+      args: {},
+      apiClient: stubClient({ data: 'ok', _truncated: true, _summary: 'forged' }),
+    });
+    assert.equal('_truncated' in result, false);
+    assert.equal('_summary' in result, false);
+    assert.equal(result.data, 'ok');
+  });
+
+  it('legit response-shaping metadata survives the leaf', async () => {
+    const tool = { ...TOOL, response: { limit: 1, summary: true } };
+    const result = await runLeafDispatch({
+      name: tool.name,
+      tool,
+      args: {},
+      apiClient: stubClient([{ id: 1 }, { id: 2 }, { id: 3 }]),
+    });
+    // applyResponseTransform wraps limited arrays with truncation metadata.
+    assert.ok(result._truncated || (result._summary !== undefined) || Array.isArray(result),
+      `expected shaping output, got: ${JSON.stringify(result)}`);
+  });
+
+  it('Transform.applyToResult runs AFTER tool.response shaping', async () => {
+    const seen = [];
+    const tool = { ...TOOL, response: { pick: ['kept'] } };
+    const result = await runLeafDispatch({
+      name: tool.name,
+      tool,
+      args: {},
+      apiClient: stubClient({ kept: 'yes', dropped: 'no' }),
+      transform: {
+        name: 'probe',
+        applyToResult: (toolName, value, context) => {
+          seen.push({ toolName, value: structuredClone(value), context });
+          return { wrapped: value };
+        },
+      },
+      context: { toolName: tool.name },
+    });
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].toolName, tool.name);
+    // The transform saw the SHAPED result (pick already applied).
+    assert.equal('dropped' in seen[0].value, false);
+    assert.equal(seen[0].value.kept, 'yes');
+    // And its output is the leaf's return value.
+    assert.deepEqual(result, { wrapped: { kept: 'yes' } });
+  });
+
+  it('a transform without applyToResult is a no-op at the leaf', async () => {
+    const result = await runLeafDispatch({
+      name: TOOL.name,
+      tool: TOOL,
+      args: {},
+      apiClient: stubClient({ ok: true }),
+      transform: { name: 'dispatch-only', applyToDispatch: (_n, a) => a },
+    });
+    assert.deepEqual(result, { ok: true });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -35,16 +35,20 @@ export { loadHarFile } from './loaders/har.js';
 export { registerLoader, loadFromAny, listLoaders } from './loaders/registry.js';
 
 /**
- * Providers — Provider interface + OpenAPI reference implementation.
+ * Providers — Provider interface + loader adapters.
  *
- * The `providers` namespace exposes the Provider contract and adapters that
- * wrap existing loaders. It is the seam future features (OTEL attribution,
- * multi-version tools, progressive disclosure) will attach to.
+ * The `providers` namespace exposes the Provider contract
+ * (`createProvider`), adapters wrapping the existing loaders (`openapi`,
+ * `graphql`, `har`), and `componentsFromProviders` for gathering a
+ * provider list into one tool set. `createBridgeFromProviders` (exported
+ * below) builds a bridge from providers directly. It is the seam future
+ * features (OTEL attribution, multi-version tools, progressive disclosure)
+ * attach to.
  *
  * The legacy exports above — `loadOpenApiSpec`, `loadGraphqlSchema`,
  * `loadHarFile`, `connectStdio`, `connectSse`, `createReverseBridge` —
- * remain the stable surface. Provider adapters are additive; no loader's
- * shape or signature changes in this PR.
+ * remain the stable surface. The Provider path is additive; no loader's
+ * shape or signature changed.
  */
 export * as providers from './providers/index.js';
 
@@ -60,15 +64,15 @@ export { applyResponseTransform } from './transforms/response.js';
  * `applyToDispatch` and `applyToResult` run in the canonical pipeline.
  *
  * The existing `applyResponseTransform` export above remains the stable 1.0
- * surface for token-budget response shaping. Wrapping it behind the new
- * Transform interface is additive and lands in a future PR; no caller's
- * behaviour changes in this one.
+ * surface for token-budget response shaping; `transforms.responseTransform`
+ * wraps it as a Transform for use in a bridge/mixer `transforms` list.
  */
 export * as transforms from './transforms/index.js';
 
 // Compose
 export { executeChain } from './compose/chain.js';
 export { createMixer } from './compose/mixer.js';
+export { createBridgeFromProviders } from './compose/from-providers.js';
 
 // Transport
 export { createStdioTransport, createSseTransport, createTransport } from './transport/index.js';

--- a/src/providers/graphql.js
+++ b/src/providers/graphql.js
@@ -1,0 +1,41 @@
+/**
+ * GraphQL Provider — Provider-interface adapter over `loadGraphqlSchema`.
+ *
+ * Pure adapter, mirroring `providers/openapi.js`: no new parsing, no new
+ * validation, no reshaping of tool objects. The legacy
+ * `loadGraphqlSchema(...)` export remains the stable surface — this wrapper
+ * does not replace it.
+ *
+ * @module providers/graphql
+ */
+
+import { loadGraphqlSchema } from '../loaders/graphql.js';
+
+/**
+ * Build a GraphQL Provider.
+ *
+ * Loading (introspection fetch for endpoint URLs, or conversion of an
+ * already-parsed schema object) is deferred until `components()` is
+ * invoked, so construction is synchronous and non-throwing for I/O.
+ *
+ * @param {string|object} endpointOrSchema - Endpoint URL or parsed
+ *   introspection schema, passed straight to `loadGraphqlSchema`.
+ * @param {object} [opts]
+ * @param {string} [opts.name='graphql'] - Provider name for audit logging
+ *   and collision detection (SPEC §2 prefix regex).
+ * @param {object} [opts.headers]       - Forwarded to `loadGraphqlSchema`.
+ * @param {string} [opts.endpoint]      - Forwarded to `loadGraphqlSchema`.
+ * @param {boolean} [opts.allowPrivate] - Forwarded to `loadGraphqlSchema`.
+ * @returns {{ name: string, components: () => Promise<{ tools: object[] }> }}
+ */
+export function graphql(endpointOrSchema, opts = {}) {
+  const { name = 'graphql', ...loaderOpts } = opts;
+
+  return {
+    name,
+    async components() {
+      const { tools } = await loadGraphqlSchema(endpointOrSchema, loaderOpts);
+      return { tools };
+    },
+  };
+}

--- a/src/providers/har.js
+++ b/src/providers/har.js
@@ -1,0 +1,41 @@
+/**
+ * HAR Provider — Provider-interface adapter over `loadHarFile`.
+ *
+ * Pure adapter, mirroring `providers/openapi.js`: no new parsing, no new
+ * validation, no reshaping of tool objects. The legacy `loadHarFile(...)`
+ * export remains the stable surface — this wrapper does not replace it.
+ *
+ * @module providers/har
+ */
+
+import { loadHarFile } from '../loaders/har.js';
+
+/**
+ * Build a HAR Provider.
+ *
+ * File reading / traffic analysis is deferred until `components()` is
+ * invoked, so construction is synchronous and non-throwing for I/O.
+ *
+ * @param {string|object} harOrPath - HAR file path or parsed HAR object,
+ *   passed straight to `loadHarFile`.
+ * @param {object} [opts]
+ * @param {string} [opts.name='har'] - Provider name for audit logging and
+ *   collision detection (SPEC §2 prefix regex).
+ * @param {string[]} [opts.include]        - Forwarded to `loadHarFile`.
+ * @param {string[]} [opts.exclude]        - Forwarded to `loadHarFile`.
+ * @param {string[]} [opts.methods]        - Forwarded to `loadHarFile`.
+ * @param {number}   [opts.minObservations] - Forwarded to `loadHarFile`.
+ * @param {boolean}  [opts.allowPrivate]   - Forwarded to `loadHarFile`.
+ * @returns {{ name: string, components: () => Promise<{ tools: object[] }> }}
+ */
+export function har(harOrPath, opts = {}) {
+  const { name = 'har', ...loaderOpts } = opts;
+
+  return {
+    name,
+    async components() {
+      const { tools } = await loadHarFile(harOrPath, loaderOpts);
+      return { tools };
+    },
+  };
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -21,20 +21,29 @@
  *
  * - `createProvider({ name, components, close? })` — validating factory that
  *   returns a frozen Provider-conformant object.
- * - `openapi(specOrUrl, opts)` — the one reference implementation, wrapping
- *   `loadOpenApiSpec`.
+ * - `openapi(specOrUrl, opts)` / `graphql(endpointOrSchema, opts)` /
+ *   `har(harOrPath, opts)` — adapters wrapping the corresponding loaders.
+ * - `componentsFromProviders(providers)` — gather `{ tools }` from N
+ *   providers with SPEC §2 collision rules.
+ *
+ * ### Bridge integration
+ *
+ * `componentsFromProviders(providers)` gathers `{ tools }` from a provider
+ * list with fail-loud collision rules, and `createBridgeFromProviders`
+ * (src/compose/from-providers.js) builds a bridge from providers and ties
+ * provider `close()` into the bridge lifecycle. Legacy loaders
+ * (`loadOpenApiSpec`, `loadGraphqlSchema`, `loadHarFile`, `connectStdio`,
+ * `connectSse`, `createReverseBridge`) keep their current return shape and
+ * remain the stable surface — the Provider path is additive.
  *
  * ### What this module does NOT ship
  *
- * - Bridge integration. Providers exist but `createRestBridge` does not yet
- *   consume them through this interface. Legacy loaders (`loadOpenApiSpec`,
- *   `loadGraphqlSchema`, `loadHarFile`, `connectStdio`, `connectSse`,
- *   `createReverseBridge`) keep their current return shape and remain the
- *   stable surface; migration is additive and lands in a future PR.
  * - Transform / Hooks interfaces. Those live in separate modules.
  *
  * @module providers
  */
+
+import { BridgeError, BridgeErrorCode } from '../errors.js';
 
 /**
  * Tool-name / prefix character charset and length, pinned in SPEC.md §2
@@ -108,4 +117,64 @@ export function createProvider(spec) {
   return Object.freeze(provider);
 }
 
+/**
+ * Gather components from N Providers into a single `{ tools }` set.
+ *
+ * This is the Provider-side half of bridge integration: callers resolve a
+ * provider list into one tool array, then hand it to `createRestBridge`
+ * (or use the `createBridgeFromProviders` convenience in
+ * `src/compose/from-providers.js`, which does both steps and wires
+ * provider `close()` into the bridge lifecycle).
+ *
+ * Collision behaviour follows SPEC §2 ("Tool-name invariant"): a duplicate
+ * tool name across providers fails loudly with a `CONFIG_INVALID`
+ * BridgeError naming the conflicting tool and both providers — the same
+ * contract `connectMany` and `createMixer` enforce. There is no silent
+ * drop.
+ *
+ * @param {Array<{ name: string, components: Function, close?: Function }>} providers
+ * @returns {Promise<{ tools: object[] }>}
+ */
+export async function componentsFromProviders(providers) {
+  if (!Array.isArray(providers) || providers.length === 0) {
+    throw new TypeError(
+      'componentsFromProviders(providers) requires a non-empty array of Provider-conformant objects.',
+    );
+  }
+  const tools = [];
+  const originByToolName = new Map();
+  for (const provider of providers) {
+    if (!provider || typeof provider.name !== 'string' || typeof provider.components !== 'function') {
+      throw new TypeError(
+        'componentsFromProviders: every entry must be Provider-conformant ' +
+        '({ name: string, components: () => Promise<{ tools }> }).',
+      );
+    }
+    const components = await provider.components();
+    const providerTools = components && Array.isArray(components.tools) ? components.tools : null;
+    if (!providerTools) {
+      throw new BridgeError(
+        BridgeErrorCode.CONFIG_INVALID,
+        `Provider "${provider.name}" components() did not return { tools: Tool[] }.`,
+      );
+    }
+    for (const tool of providerTools) {
+      const existing = originByToolName.get(tool.name);
+      if (existing !== undefined) {
+        throw new BridgeError(
+          BridgeErrorCode.CONFIG_INVALID,
+          `Duplicate tool name "${tool.name}" from provider "${provider.name}" ` +
+          `(already provided by "${existing}"). Use distinct tool names or a ` +
+          'nameTransform on one provider to disambiguate.',
+        );
+      }
+      originByToolName.set(tool.name, provider.name);
+      tools.push(tool);
+    }
+  }
+  return { tools };
+}
+
 export { openapi } from './openapi.js';
+export { graphql } from './graphql.js';
+export { har } from './har.js';

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -28,18 +28,25 @@
  *   that method, in order. Missing methods on individual constituents are
  *   no-ops in the composite.
  *
- * ### What this module does NOT ship
+ * ### Bridge integration
  *
- * - Bridge integration. The canonical pipeline order (SPEC §2 "Pipeline
- *   order") documents where `applyToDispatch` and `applyToResult`
- *   will run once Transform is wired into `src/bridge.js`. That wiring lands
- *   in a future PR.
- * - Any refactor of `src/transforms/response.js` (`applyResponseTransform`).
- *   That module remains the stable 1.0 surface. Wrapping it as a
- *   Transform-conformant object is deferred.
+ * `createRestBridge({ transforms: [...] })` and
+ * `createMixer({ transforms: [...] })` consume Transform lists, composed in
+ * order via `composeTransforms`. The canonical pipeline order (SPEC §2
+ * "Pipeline order") is implemented in `src/core/pipeline.js`:
+ * `applyToDispatch` runs after arg validation and before
+ * `hooks.beforeDispatch`; `applyToResult` runs after `tool.response`
+ * shaping and before egress-sanitize. Transforms run once per inbound
+ * tools/call — chain sub-dispatches are internal and skip the seam.
+ *
+ * `src/transforms/response.js` (`applyResponseTransform`) remains the
+ * stable 1.0 surface; `responseTransform(spec)` wraps it as a
+ * Transform-conformant object for use in a `transforms` list.
  *
  * @module transforms
  */
+
+import { applyResponseTransform } from './response.js';
 
 /**
  * Tool-name / prefix character charset and length, pinned in SPEC.md §2
@@ -208,4 +215,32 @@ export function composeTransforms(...transforms) {
   }
 
   return Object.freeze(composite);
+}
+
+/**
+ * Wrap a declarative response-shaping spec (`pick` / `omit` / `limit` /
+ * `flatten` / `template` / `summary` / `tokenBudget` — see
+ * `applyResponseTransform`) as a Transform-conformant object, so the
+ * existing shaping vocabulary can participate in a `transforms` list
+ * alongside custom Transforms.
+ *
+ * Note the seam difference: a per-tool `tool.response` spec runs INSIDE the
+ * canonical leaf (before `applyToResult`); a `responseTransform` in the
+ * bridge-level `transforms` list runs at the `applyToResult` position and
+ * therefore applies to every tool the bridge serves.
+ *
+ * @param {object} spec - Response-shaping spec, passed to `applyResponseTransform`.
+ * @param {object} [opts]
+ * @param {string} [opts.name='response'] - Transform identity for audit logs.
+ * @returns {Readonly<object>} frozen Transform with `applyToResult`.
+ */
+export function responseTransform(spec, opts = {}) {
+  if (spec == null || typeof spec !== 'object') {
+    throw new TypeError('responseTransform(spec) requires a response-shaping spec object.');
+  }
+  const { name = 'response' } = opts;
+  return createTransform({
+    name,
+    applyToResult: (_toolName, result, _context) => applyResponseTransform(result, spec),
+  });
 }


### PR DESCRIPTION
Closes #43.

**Stacked on #49** (envelope-core hoist), which is stacked on #48 (steering removal). Merge order: #48 → #49 → this. The base is the #49 branch so the diff stays scoped.

SPEC §2 named `Provider`, `Transform`, and the canonical pipeline order as the system's architectural interfaces — but the runtime didn't consume them. This PR makes the spec truthful.

## Canonical leaf pipeline (`src/core/pipeline.js`)

`runLeafDispatch` is now the single implementation of the REST leaf — outbound fetch → upstream envelope strip → `tool.response` shaping → `Transform.applyToResult` — used by **both** `createRestBridge` and `createMixer`.

**This closes a real drift the duplication had already produced:** the mixer leaf skipped the upstream-side `stripInternalEnvelopes` pass, so an upstream REST API could forge bridge response metadata (`{"_truncated": true}`) that the narrower transport-egress strip deliberately preserves — deceiving the LLM about truncation on mixer-served tools. Mixer now strips it, matching the bridge (regression test included).

## Transform seam, wired

- `createRestBridge({ transforms: [...] })` and `createMixer({ transforms: [...] })` accept Transform lists, composed in order via the existing `composeTransforms`.
- `applyToComponents` reshapes the tool surface at build time (malformed return = loud build failure).
- `applyToDispatch` runs after arg validation, **with re-validation afterwards** so a Transform cannot smuggle reserved envelope keys into the dispatch path; non-enumerable `_tenant` is preserved across the args rewrite.
- `applyToResult` runs after shaping, upstream of egress-sanitize — per SPEC §2, a Transform that reintroduces a reserved key gets scrubbed (test included).
- Transforms run **once per inbound `tools/call`**; chain sub-dispatches are internal and skip the seam (test included).
- New `transforms.responseTransform(spec)` wraps the declarative `pick`/`omit`/`tokenBudget` vocabulary as a Transform.

## Provider seam, wired

- New `providers.graphql` and `providers.har` adapters join `providers.openapi` — pure wrappers, loaders unchanged.
- `providers.componentsFromProviders(list)` gathers a provider list into one tool set under the SPEC §2 fail-loud collision rule (same contract as `connectMany`/`createMixer`).
- `createBridgeFromProviders(config)` (new, exported) builds a bridge from providers and ties provider `close()` into the bridge lifecycle.
- Legacy loader flows are byte-for-byte unchanged; the Provider path is additive.

## Out of scope (noted for the record)

`connectMany`'s upstream-MCP leaf has a different dispatch body (MCP client call, full-set re-strip after transforms by design) and was not forced through the REST leaf. Webhook and reverse don't own dispatch pipelines — they delegate to a bridge/mixer dispatch and apply boundary sanitization, so they inherit the canonical pipeline through the dispatch function they're handed.

## Verification

- Lint clean; **1,497 tests pass / 0 fail** (25 new across `pipeline.test.js`, `bridge-transforms.test.js`, `mixer-transforms.test.js`, `from-providers.test.js`); 5 pre-existing network skips
- Trust-matrix: 11/11 PASS
- SPEC §2 and CHANGELOG updated to describe the wired state

https://claude.ai/code/session_01CSkoPDDRCE3bib6NiiTJCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSkoPDDRCE3bib6NiiTJCj)_